### PR TITLE
 CONTRIBUTING.md review and updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Most operating systems provide all the needed tools (including Windows, Linux an
 
   - [Docker](https://docs.docker.com/get-docker/) and [Docker Compose Plugin](https://docs.docker.com/compose/install/)
     - It is not mandatory because you can easily locally run tests against SQLite without it.
-    - It is practically mandatory if you want to locally run tests against any other database engine (MySQL, MariaDB, Postgres,Db2 and MSSQL), unless you happen to have the engine installed and is willing to make some manual configuration.
+    - It is practically mandatory if you want to locally run tests against any other database engine (MySQL, MariaDB, Postgres,Db2 and MSSQL), unless you happen to have the engine installed and are willing to make some manual configuration.
   - [Visual Studio Code](https://code.visualstudio.com/)
     - [EditorConfig extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
       - Also run `npm install --global editorconfig` (or `yarn global add editorconfig`) to make sure this extension will work properly
@@ -110,14 +110,23 @@ Run `npm ci` within the cloned repository folder.
 
 ### 3. Prepare local databases to run tests
 
-If you're happy to run tests only against an SQLite database, you can skip this section.
+#### 3.1. With SQLite
 
-#### 3.1. With Docker (recommended)
+No further configuration is required to test Hatchify against a SQLite database.
+
+#### 3.2. With a database engine in a Docker container (recommended)
 
 If you have Docker installed, use any of the following commands to start fresh local databases of the dialect of your choice:
 
-- `docker run --name postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres`
-- `docker run --name mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:tag`
+- For PostgreSQL
+    ```bash
+    docker run --name postgres -e POSTGRES_PASSWORD=mysecretpassword -d postgres
+    ```
+
+- For MySQL
+    ```bash
+    docker run --name mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d mysql:tag
+    ```
 
 _Note:_ if you're using Windows, make sure you run these from Git Bash (or another MinGW environment), since these commands will execute bash scripts. Recall that [it's very easy to include Git Bash as your default integrated terminal on Visual Studio Code](https://code.visualstudio.com/docs/editor/integrated-terminal).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,11 @@ Issues are always very welcome - after all, they are a big part of making Hatchi
 
 If you open an issue, try to be as clear as possible. Don't assume that the maintainers will immediately understand the problem. Write your issue in a way that new contributors can also help (add links to helpful resources when applicable).
 
-Make sure you know what is an [SSCCE](http://sscce.org/)/[MCVE](https://stackoverflow.com/help/minimal-reproducible-example).
-
 Learn to use [GitHub flavored markdown](https://help.github.com/articles/github-flavored-markdown) to write an issue that is nice to read.
 
 ### Opening an issue to report a bug
 
-It is essential that you provide an [SSCCE](http://sscce.org/)/[MCVE](https://stackoverflow.com/help/minimal-reproducible-example) for your issue. You can use the [papb/hatchify-sscce](https://github.com/papb/hatchify-sscce) repository. Tell us what is the actual (incorrect) behavior and what should have happened (do not expect the maintainers to know what should happen!). Make sure you checked the bug persists in the latest Hatchify version.
+It is essential that you provide an [SSCCE](http://sscce.org/)/[MCVE](https://stackoverflow.com/help/minimal-reproducible-example) for your issue. Tell us what is the actual (incorrect) behavior and what should have happened (do not expect the maintainers to know what should happen!). Make sure you checked the bug persists in the latest Hatchify version.
 
 If you can even provide a Pull Request with a failing test (unit test or integration test), that is great! The bug will likely be fixed much faster in this case.
 


### PR DESCRIPTION
- the hatchify-sscce repo linked to does not exist.  Its link has been removed and the recommendation for SSCCE/MCVE is localized to bug reporting, where it is more contextually relevant.
- I added a subsection for SQLite in setting up test DBs to make it clearer that SQLite is one option separate from a Docker-installed DB.  I also recommend adding a subsection that says "setting up a test DB on your host environment without Docker is outside the scope of this document"
- I recommend moving common issues/troubleshooting/FAQs out of the contrib guide here and into the getting started guide, but that's on its own dev process right now so the existing problem might get lost if it's removed from here right now.