### PR TITLE
Add support for object-type attributes in rest-client

### DIFF
--- a/packages/hatchify-core/src/types/schema.ts
+++ b/packages/hatchify-core/src/types/schema.ts
@@ -1,5 +1,4 @@
-export type AttributeObject = { type: string }
-export type Attribute = string | AttributeObject
+export type Attribute = string | { type: string }
 
 export interface Relationship {
   target: string

--- a/packages/hatchify-core/src/types/schema.ts
+++ b/packages/hatchify-core/src/types/schema.ts
@@ -1,3 +1,6 @@
+export type AttributeObject = { type: string }
+export type Attribute = string | AttributeObject
+
 export interface Relationship {
   target: string
   options: {
@@ -8,7 +11,7 @@ export interface Relationship {
 export interface Schema {
   name: string
   attributes: {
-    [field: string]: string
+    [field: string]: Attribute
   }
   hasOne?: Relationship[]
   hasMany?: Relationship[]

--- a/packages/rest-client/src/services/types/schema.ts
+++ b/packages/rest-client/src/services/types/schema.ts
@@ -1,4 +1,5 @@
-export type Attribute = string | { type: string }
+export type AttributeObject = { type: string }
+export type Attribute = string | AttributeObject
 
 export interface Schema {
   name: string // "Article"

--- a/packages/rest-client/src/services/utils/schema/schema.test.ts
+++ b/packages/rest-client/src/services/utils/schema/schema.test.ts
@@ -93,6 +93,5 @@ describe("rest-client/services/utils/schema", () => {
       const result = transformSchema(schema)
       expect(result).toEqual(expected)
     })
-
   })
 })

--- a/packages/rest-client/src/services/utils/schema/schema.test.ts
+++ b/packages/rest-client/src/services/utils/schema/schema.test.ts
@@ -58,5 +58,41 @@ describe("rest-client/services/utils/schema", () => {
       const result = transformSchema(schema)
       expect(result).toEqual(expected)
     })
+    it("works for object attributes", () => {
+      const schema: OldSchema = {
+        name: "Article",
+        attributes: {
+          id: { type: "UUID" },
+          title: { type: "VARCHAR(100)" },
+          body: { type: "LONGTEXT" },
+          wordCount: { type: "INTEGER" },
+        },
+        hasMany: [{ target: "Comment", options: { as: "comments" } }],
+        hasOne: [{ target: "Person", options: { as: "author" } }],
+        belongsTo: [{ target: "Collection", options: { as: "collections" } }],
+        belongsToMany: [{ target: "Websites", options: { as: "website" } }],
+      }
+
+      const expected: Schema = {
+        name: "Article",
+        displayAttribute: "id",
+        attributes: {
+          id: "string",
+          title: "string",
+          body: "string",
+          wordCount: "number",
+        },
+        relationships: {
+          comments: { type: "many", schema: "Comment" },
+          author: { type: "one", schema: "Person" },
+          collections: { type: "one", schema: "Collection" },
+          website: { type: "many", schema: "Websites" },
+        },
+      }
+
+      const result = transformSchema(schema)
+      expect(result).toEqual(expected)
+    })
+
   })
 })

--- a/packages/rest-client/src/services/utils/schema/schema.ts
+++ b/packages/rest-client/src/services/utils/schema/schema.ts
@@ -1,5 +1,5 @@
 import type { Schema as OldSchema } from "@hatchifyjs/hatchify-core"
-import type { Schema } from "../../types"
+import type { Schema, AttributeObject } from "../../types"
 
 /**
  * The current backend schema attribute types are sequelize datatypes. This function
@@ -50,7 +50,14 @@ export function transformSchema(schema: OldSchema): Schema {
   }
 
   for (const [key, value] of Object.entries(schema.attributes)) {
-    resolved.attributes[key] = transformDataType(value)
+    let stringValue: string
+    if (typeof value === "string") {
+      stringValue = value
+    } else {
+      stringValue = (value as AttributeObject).type as string
+    }
+
+    resolved.attributes[key] = transformDataType(stringValue)
   }
 
   if (


### PR DESCRIPTION
This is already supported by the type definition, but generated an error when transforming hatchify core schemata into rest-client schemata.  This PR fixes the issue with using an object for attribute types.