### PR TITLE
HATCH-206: Handle Missing Data

### DIFF
--- a/packages/express/src/attributes.spec.ts
+++ b/packages/express/src/attributes.spec.ts
@@ -30,8 +30,13 @@ describe("Attribute Tests", () => {
     await hatchify.createDatabase()
 
     const create = await POST(server, "/api/models", {
-      firstName: "firstName",
-      lastName: "lastName",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName",
+          lastName: "lastName",
+        },
+      },
     })
 
     expect(create).toBeTruthy()
@@ -72,8 +77,13 @@ describe("Attribute Tests", () => {
     await hatchify.createDatabase()
 
     const create = await POST(server, "/api/models", {
-      firstName: "firstName",
-      lastName: "lastName",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName",
+          lastName: "lastName",
+        },
+      },
     })
 
     expect(create).toBeTruthy()
@@ -100,18 +110,33 @@ describe("Attribute Tests", () => {
     await hatchify.createDatabase()
 
     await POST(server, "/api/models", {
-      firstName: "firstName1",
-      lastName: "lastName1",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName1",
+          lastName: "lastName1",
+        },
+      },
     })
 
     await POST(server, "/api/models", {
-      firstName: "firstName2",
-      lastName: "lastName2",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName2",
+          lastName: "lastName2",
+        },
+      },
     })
 
     await POST(server, "/api/models", {
-      firstName: "firstName3",
-      lastName: "lastName3",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName3",
+          lastName: "lastName3",
+        },
+      },
     })
 
     const find1 = await GET(server, "/api/models/?fields[Model]=firstName")

--- a/packages/express/src/middleware/express.ts
+++ b/packages/express/src/middleware/express.ts
@@ -96,6 +96,6 @@ export async function errorMiddleware(
   } catch (error) {
     const { errors, status } = errorResponseHandler(error)
 
-    res.status(status).json(errors)
+    res.status(status).json({ jsonapi: { version: "1.0" }, errors })
   }
 }

--- a/packages/express/src/testing/utils.ts
+++ b/packages/express/src/testing/utils.ts
@@ -1,6 +1,55 @@
+import type { HatchifyModel } from "@hatchifyjs/node"
 import { HatchifyError, codes, statusCodes } from "@hatchifyjs/node"
+import Express from "express"
+import type { NextFunction, Request, Response } from "express"
 import { Deserializer } from "jsonapi-serializer"
 import request from "supertest"
+
+import { Hatchify, errorHandlerMiddleware } from "../express"
+
+type Method = "get" | "post" | "patch" | "delete"
+type Middleware = (req: Request, res: Response, next: NextFunction) => void
+
+export async function startServerWith(
+  models: HatchifyModel[],
+  middleware?: Middleware[],
+): Promise<{
+  fetch: (
+    path: string,
+    options?: { method?: Method; headers?: object; body: object },
+  ) => Promise<any>
+  teardown: () => Promise<void>
+}> {
+  const app = Express()
+  const hatchify = new Hatchify(models, { prefix: "/api" })
+  app.use(errorHandlerMiddleware)
+  app.use(hatchify.middleware.allModels.all)
+
+  const server = app
+  await hatchify.createDatabase()
+
+  async function fetch(
+    path: string,
+    options?: { method?: Method; headers?: object; body: object },
+  ) {
+    const method = options?.method || "get"
+    const headers = options?.headers || {}
+    const body = options?.body
+    const response = request(server)[method](path)
+
+    Object.entries(headers).forEach(([key, value]) => response.set(key, value))
+
+    if (body) {
+      response.send(body)
+    }
+    return response
+  }
+
+  return {
+    fetch,
+    teardown: async () => hatchify.orm.close(),
+  }
+}
 
 async function parse(result) {
   let serialized

--- a/packages/koa/src/attributes.spec.ts
+++ b/packages/koa/src/attributes.spec.ts
@@ -30,8 +30,13 @@ describe("Attribute Tests", () => {
     await hatchify.createDatabase()
 
     const create = await POST(server, "/api/models", {
-      firstName: "firstName",
-      lastName: "lastName",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName",
+          lastName: "lastName",
+        },
+      },
     })
 
     expect(create).toBeTruthy()
@@ -72,8 +77,13 @@ describe("Attribute Tests", () => {
     await hatchify.createDatabase()
 
     const create = await POST(server, "/api/models", {
-      firstName: "firstName",
-      lastName: "lastName",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName",
+          lastName: "lastName",
+        },
+      },
     })
 
     expect(create).toBeTruthy()
@@ -100,18 +110,33 @@ describe("Attribute Tests", () => {
     await hatchify.createDatabase()
 
     await POST(server, "/api/models", {
-      firstName: "firstName1",
-      lastName: "lastName1",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName1",
+          lastName: "lastName1",
+        },
+      },
     })
 
     await POST(server, "/api/models", {
-      firstName: "firstName2",
-      lastName: "lastName2",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName2",
+          lastName: "lastName2",
+        },
+      },
     })
 
     await POST(server, "/api/models", {
-      firstName: "firstName3",
-      lastName: "lastName3",
+      data: {
+        type: "Model",
+        attributes: {
+          firstName: "firstName3",
+          lastName: "lastName3",
+        },
+      },
     })
 
     const find1 = await GET(server, "/api/models/?fields[Model]=firstName")

--- a/packages/koa/src/middleware/koa.ts
+++ b/packages/koa/src/middleware/koa.ts
@@ -91,6 +91,6 @@ export async function errorMiddleware(
     const { errors, status } = errorResponseHandler(error)
 
     ctx.status = status
-    ctx.body = errors
+    ctx.body = { jsonapi: { version: "1.0" }, errors }
   }
 }

--- a/packages/koa/src/relationships.spec.ts
+++ b/packages/koa/src/relationships.spec.ts
@@ -33,17 +33,39 @@ describe("Relationships", () => {
   })
 
   it("should always return type and id (HATCH-167)", async () => {
-    const { body: user } = await fetch("/api/users", {
+    const { body: todo } = await fetch("/api/todos", {
       method: "post",
       body: {
-        name: "John Doe",
-        todos: [
-          {
+        data: {
+          type: "Todo",
+          attributes: {
             name: "Walk the dog",
             due_date: "2024-12-12T00:00:00.000Z",
             importance: 6,
           },
-        ],
+        },
+      },
+    })
+
+    const { body: user } = await fetch("/api/users", {
+      method: "post",
+      body: {
+        data: {
+          type: "User",
+          attributes: {
+            name: "John Doe",
+          },
+          relationships: {
+            todos: {
+              data: [
+                {
+                  type: "Todo",
+                  id: todo.data.id,
+                },
+              ],
+            },
+          },
+        },
       },
     })
 
@@ -128,21 +150,35 @@ describe("Relationships", () => {
       const { body: todo } = await fetch("/api/todos", {
         method: "post",
         body: {
-          name: "Walk the dog",
-          due_date: "2024-12-12T00:00:00.000Z",
-          importance: 6,
+          data: {
+            attributes: {
+              name: "Walk the dog",
+              due_date: "2024-12-12T00:00:00.000Z",
+              importance: 6,
+            },
+          },
         },
       })
 
       const { body: user } = await fetch("/api/users", {
         method: "post",
         body: {
-          name: "John Doe",
-          todos: [
-            {
-              id: todo.data.id,
+          data: {
+            type: "User",
+            attributes: {
+              name: "John Doe",
             },
-          ],
+            relationships: {
+              todos: {
+                data: [
+                  {
+                    type: "Todo",
+                    id: todo.data.id,
+                  },
+                ],
+              },
+            },
+          },
         },
       })
 
@@ -176,18 +212,28 @@ describe("Relationships", () => {
       const { body: user } = await fetch("/api/users", {
         method: "post",
         body: {
-          name: "John Doe",
+          data: {
+            type: "User",
+            attributes: {
+              name: "John Doe",
+            },
+          },
         },
       })
 
       const { body: todo } = await fetch("/api/todos", {
         method: "post",
         body: {
-          name: "Walk the dog",
-          due_date: "2024-12-12T00:00:00.000Z",
-          importance: 7,
-          user: {
-            id: user.data.id,
+          data: {
+            type: "Todo",
+            attributes: {
+              name: "Walk the dog",
+              due_date: "2024-12-12T00:00:00.000Z",
+              importance: 7,
+            },
+            relationships: {
+              user: { data: { type: "User", id: user.data.id } },
+            },
           },
         },
       })
@@ -219,17 +265,27 @@ describe("Relationships", () => {
     })
   })
 
-  describe("should handle validation errors (HATCH-186)", () => {
+  describe.skip("should handle validation errors (HATCH-186)", () => {
     it("should handle non-existing associations", async () => {
       const { status, body } = await fetch("/api/users", {
         method: "post",
         body: {
-          name: "John Doe",
-          todos: [
-            {
-              id: "-1",
+          data: {
+            type: "User",
+            attributes: {
+              name: "John Doe",
             },
-          ],
+            relationships: {
+              todos: {
+                data: [
+                  {
+                    type: "Todo",
+                    id: -1,
+                  },
+                ],
+              },
+            },
+          },
         },
       })
 
@@ -251,13 +307,13 @@ describe("Relationships", () => {
         fetch("/api/users", {
           method: "post",
           body: {
-            name: "Mr. Pagination",
+            data: { attributes: { name: "Mr. Pagination" } },
           },
         }),
         fetch("/api/users", {
           method: "post",
           body: {
-            name: "Mrs. Pagination",
+            data: { attributes: { name: "Mrs. Pagination" } },
           },
         }),
       ])
@@ -280,7 +336,7 @@ describe("Relationships", () => {
         fetch("/api/users", {
           method: "post",
           body: {
-            name: "Mr. No Pagination",
+            data: { attributes: { name: "Mr. No Pagination" } },
           },
         }),
       ])

--- a/packages/koa/src/testing/utils.ts
+++ b/packages/koa/src/testing/utils.ts
@@ -7,7 +7,7 @@ import Koa from "koa"
 import type { Context } from "koa"
 import request from "supertest"
 
-import { Hatchify } from "../koa"
+import { Hatchify, errorHandlerMiddleware } from "../koa"
 
 type Method = "get" | "post" | "patch" | "delete"
 type Middleware = (ctx: Context) => void
@@ -24,6 +24,7 @@ export async function startServerWith(
 }> {
   const app = new Koa()
   const hatchify = new Hatchify(models, { prefix: "/api" })
+  app.use(errorHandlerMiddleware)
   app.use(hatchify.middleware.allModels.all)
 
   const server = http.createServer(app.callback())

--- a/packages/node/src/error/constants.ts
+++ b/packages/node/src/error/constants.ts
@@ -9,6 +9,7 @@ export enum codes {
   ERR_DATABASE_ERROR = "database-error",
   ERR_INVALID_RESULT = "invalid-result",
   ERR_SERVER_ERROR = "server-error",
+  ERR_MISSING_DATA = "missing-data",
 }
 
 export enum statusCodes {

--- a/packages/node/src/error/errors.ts
+++ b/packages/node/src/error/errors.ts
@@ -1,13 +1,7 @@
 import { codes, statusCodes } from "./constants"
 
-class Source {
-  pointer?: string
-  parameter?: string
-
-  constructor(pointer?: string, parameter?: string) {
-    this.pointer = pointer && "/data/attributes/" + pointer
-    this.parameter = parameter
-  }
+interface Source {
+  pointer: string
 }
 
 interface HatchifyErrorOptions {
@@ -39,8 +33,11 @@ class HatchifyError extends Error {
     this.status = status || statusCodes.INTERNAL_SERVER_ERROR
     this.code = code || codes.ERR_SERVER_ERROR
     this.detail = detail
-    this.source = new Source(pointer, parameter)
     this.title = title || "Server Error ocurred"
+
+    if (pointer) {
+      this.source = { pointer }
+    }
   }
 }
 
@@ -78,6 +75,18 @@ class ConflictError extends HatchifyError {
   }
 }
 
+class MissingDataError extends HatchifyError {
+  constructor() {
+    super({
+      status: statusCodes.UNPROCESSABLE_ENTITY,
+      code: codes.ERR_MISSING_DATA,
+      title: "'data' must be specified for this operation.",
+      detail: "Payload was missing 'data' field. It can not be null/undefined.",
+      pointer: "/data",
+    })
+  }
+}
+
 export type { HatchifyErrorOptions }
 export {
   HatchifyError,
@@ -85,4 +94,5 @@ export {
   NotFoundError,
   UniqueConstraintError,
   ConflictError,
+  MissingDataError,
 }

--- a/packages/node/src/error/index.ts
+++ b/packages/node/src/error/index.ts
@@ -1,5 +1,5 @@
-import { codes, statusCodes } from "./constants"
-import { HatchifyError } from "./errors"
+import { statusCodes } from "./constants"
+import type { HatchifyError } from "./errors"
 import { databaseErrorHandlers } from "./types/database-errors"
 import type { SequelizeError } from "./types/database-errors"
 import { hatchifyErrorHandler } from "./types/general-errors"
@@ -12,24 +12,7 @@ export interface ErrorResponse {
 }
 
 export function errorResponseHandler(error: Error): ErrorResponse {
-  if (error.name === "ValidationError") {
-    return {
-      errors: [
-        new HatchifyError({
-          title: error.message,
-          code: codes.ERR_INVALID_PARAMETER,
-          status: statusCodes.BAD_REQUEST,
-        }),
-      ],
-      status: statusCodes.BAD_REQUEST,
-    }
-  }
-
   const errors: GeneralError[] = []
-
-  let status = statusCodes.INTERNAL_SERVER_ERROR
-
-  console.error("Internal Server Error:", error)
 
   if (
     [
@@ -44,7 +27,8 @@ export function errorResponseHandler(error: Error): ErrorResponse {
     errors.push(hatchifyErrorHandler(error as HatchifyError))
   }
 
-  status = errors[0].status || status
-
-  return { errors, status }
+  return {
+    errors,
+    status: errors[0].status || statusCodes.INTERNAL_SERVER_ERROR,
+  }
 }

--- a/packages/node/src/middleware/node.ts
+++ b/packages/node/src/middleware/node.ts
@@ -1,3 +1,5 @@
+import type { ErrorObject } from "json-api-serializer"
+
 import { errorResponseHandler } from "../error"
 import { codes, statusCodes } from "../error/constants"
 import { ValidationError } from "../error/errors"
@@ -254,7 +256,10 @@ export function handleAllMiddleware(hatchify: Hatchify) {
     } catch (error) {
       const { errors, status } = errorResponseHandler(error)
 
-      return { status, body: errors }
+      return {
+        status,
+        body: { jsonapi: { version: "1.0" }, errors: errors as ErrorObject[] },
+      }
     }
   }
 }

--- a/packages/node/src/parse/index.spec.ts
+++ b/packages/node/src/parse/index.spec.ts
@@ -193,17 +193,6 @@ describe("index", () => {
     })
 
     describe("create", () => {
-      it("works with deserialized body", async () => {
-        const body = {
-          name: "Laundry",
-          due_date: "2024-12-02",
-          importance: 1,
-        }
-        const results = await create(body)
-
-        expect(results).toEqual({ body, ops: {} })
-      })
-
       it("works with serialized body", async () => {
         const body = {
           data: {
@@ -224,27 +213,24 @@ describe("index", () => {
     describe("update", () => {
       it("works with ID", async () => {
         const body = {
-          name: "Laundry",
-          due_date: "2024-12-02",
-          importance: 1,
+          data: {
+            type: "Todo",
+            attributes: {
+              name: "Laundry",
+              due_date: "2024-12-02",
+              importance: 1,
+            },
+          },
         }
         const results = await update(body, 1)
 
-        expect(results).toEqual({ body, ops: { where: { id: 1 } } })
+        expect(results).toEqual({
+          body: body.data.attributes,
+          ops: { where: { id: 1 } },
+        })
       })
 
       it("works without ID", async () => {
-        const body = {
-          name: "Laundry",
-          due_date: "2024-12-02",
-          importance: 1,
-        }
-        const results = await update(body)
-
-        expect(results).toEqual({ body, ops: { where: {} } })
-      })
-
-      it("works with serialized body", async () => {
         const body = {
           data: {
             type: "Todo",

--- a/packages/node/src/parse/index.ts
+++ b/packages/node/src/parse/index.ts
@@ -8,7 +8,7 @@ import type {
 
 import { buildDestroyOptions, buildFindOptions } from "./builder"
 import { codes, statusCodes } from "../error/constants"
-import { ValidationError } from "../error/errors"
+import { MissingDataError, ValidationError } from "../error/errors"
 import type { Hatchify } from "../node"
 import type { HatchifyModel, JSONObject } from "../types"
 
@@ -76,11 +76,11 @@ async function findAndCountAllImpl(model: HatchifyModel, querystring: string) {
 async function createImpl<T extends HatchifyModel = HatchifyModel>(
   hatchify: Hatchify,
   model: T,
-  body: unknown,
+  body: any,
 ) {
-  const parsed = await hatchify.serializer.deserialize(model.name, body as any)
-  // FOR NON-JSON:API Compliant, parsed is an empty object
-  const parsedBody = Object.keys(parsed).length === 0 ? body : parsed
+  if (!body.data) throw new MissingDataError()
+
+  const parsedBody = await hatchify.serializer.deserialize(model.name, body)
 
   return {
     body: parsedBody,
@@ -91,12 +91,12 @@ async function createImpl<T extends HatchifyModel = HatchifyModel>(
 async function updateImpl(
   hatchify: Hatchify,
   model: HatchifyModel,
-  body: unknown,
+  body: any,
   id,
 ) {
-  const parsed = await hatchify.serializer.deserialize(model.name, body as any)
-  // FOR NON-JSON:API Compliant, parsed is an empty object
-  const parsedBody = Object.keys(parsed).length === 0 ? body : parsed
+  if (!body.data) throw new MissingDataError()
+
+  const parsedBody = await hatchify.serializer.deserialize(model.name, body)
 
   return {
     body: parsedBody,

--- a/packages/node/src/types/index.ts
+++ b/packages/node/src/types/index.ts
@@ -13,7 +13,6 @@ import type {
 } from "sequelize"
 import type { ModelHooks } from "sequelize/types/hooks"
 
-import type { GeneralError } from "../error"
 import type { Hatchify } from "../node"
 
 export { DataTypes } from "sequelize"
@@ -215,7 +214,7 @@ export interface MiddlewareRequest {
 }
 
 export interface MiddlewareResponse {
-  body: JSONAPIDocument | GeneralError[]
+  body: JSONAPIDocument
   status?: number
 }
 


### PR DESCRIPTION
* Changing tests to always use JSON:API so they all have `data` in the payload
* Fixing error middleware to return errors like we expect
* Handling the first type of error
* Reverting HATCH-186 as it implemented differently than our current approach