### PR TITLE
feat: ensure relationships.belongsToMany.options.foreignKey is tested

### DIFF
--- a/packages/koa/src/naming.spec.ts
+++ b/packages/koa/src/naming.spec.ts
@@ -1,0 +1,111 @@
+import type { HatchifyModel } from "@hatchifyjs/node"
+
+import { startServerWith } from "./testing/utils"
+
+type Method = "get" | "post" | "patch" | "delete"
+
+interface Request {
+  url: string
+  options: {
+    method: Method
+    body?: Record<string, unknown>
+  }
+  expected: {
+    body: Record<string, unknown>
+    status: number
+  }
+}
+
+interface Table {
+  tableName: string
+  columns: string[]
+}
+interface TestCase {
+  description: string
+  models: HatchifyModel[]
+  requests: Request[]
+  database: Table[]
+}
+
+describe("Naming rules", () => {
+  const attributeNameTestCases: TestCase[] = [
+    {
+      description:
+        "Ensure belongsToMany attributes are correctly created as rows and can be fetched",
+      models: [
+        {
+          name: "SalesPerson",
+          attributes: {
+            firstName: "STRING",
+          },
+          belongsToMany: [
+            {
+              target: "Account",
+              options: { foreignKey: "seller_id" },
+            },
+          ],
+        },
+        {
+          name: "Account",
+          attributes: {
+            name: "STRING",
+          },
+          hasOne: [
+            {
+              target: "SalesPerson",
+            },
+          ],
+        },
+      ],
+      requests: [],
+      database: [
+        {
+          tableName: "account_sales_person",
+          columns: ["seller_id", "account_id"],
+        },
+      ],
+    },
+  ]
+
+  const cases: TestCase[] = [...attributeNameTestCases]
+
+  let fetch: Awaited<ReturnType<typeof startServerWith>>["fetch"]
+  let teardown: Awaited<ReturnType<typeof startServerWith>>["teardown"]
+  let hatchify: Awaited<ReturnType<typeof startServerWith>>["hatchify"]
+
+  afterAll(async () => {
+    await teardown()
+  })
+
+  it.each(cases)(
+    "$description",
+    async ({ description, models, database, requests }) => {
+      ;({ fetch, teardown, hatchify } = await startServerWith(
+        [...models],
+        false,
+      ))
+
+      for (const request of requests) {
+        const { expected, options, url } = request
+        const { body: expectedBody, status: expectedStatus } = expected
+
+        const { body, status } = await fetch(url, options)
+
+        expect(body).toStrictEqual(expectedBody)
+        expect(status).toStrictEqual(expectedStatus)
+      }
+
+      for (const table of database) {
+        const { columns: expectedColumns, tableName } = table
+
+        const [dbResult] = await hatchify._sequelize.query(
+          `SELECT name FROM pragma_table_info("${tableName}")`,
+        )
+
+        const columns = dbResult.map((row) => row.name)
+
+        expect(columns).toEqual(expect.arrayContaining(expectedColumns))
+      }
+    },
+  )
+})

--- a/packages/koa/src/testing/utils.ts
+++ b/packages/koa/src/testing/utils.ts
@@ -14,6 +14,7 @@ type Middleware = (ctx: Context) => void
 
 export async function startServerWith(
   models: HatchifyModel[],
+  usesPrefix: boolean,
   middleware?: Middleware[],
 ): Promise<{
   fetch: (
@@ -21,9 +22,11 @@ export async function startServerWith(
     options?: { method?: Method; headers?: object; body?: object },
   ) => Promise<any>
   teardown: () => Promise<void>
+  hatchify?
 }> {
   const app = new Koa()
-  const hatchify = new Hatchify(models, { prefix: "/api" })
+  const prefix = usesPrefix ? "/api" : undefined
+  const hatchify = new Hatchify(models, { prefix })
   app.use(errorHandlerMiddleware)
   app.use(hatchify.middleware.allModels.all)
 
@@ -50,6 +53,7 @@ export async function startServerWith(
   return {
     fetch,
     teardown: async () => hatchify.orm.close(),
+    hatchify,
   }
 }
 


### PR DESCRIPTION
This PR intends to fullfill: https://bitovi.atlassian.net/browse/HATCH-278
The tests are not currently passing, though. Will be addressed in future PR, **do not merge**.