### PR TITLE
[HATCHIFY-322] Align belongsToMany associations code with naming.md

### DIFF
--- a/doc/naming.md
+++ b/doc/naming.md
@@ -419,7 +419,7 @@ const SalesPerson = {
   belongsToMany: [
     {
       target: "Account",
-      options: { through: "sales_account" },
+      options: { through: "SalesAccount" },
     },
   ],
 }

--- a/packages/node/src/sequelize/v1/convertHatchifyModels.spec.ts
+++ b/packages/node/src/sequelize/v1/convertHatchifyModels.spec.ts
@@ -14,6 +14,14 @@ describe("convertHatchifyModels", () => {
       name: "STRING",
     },
     hasMany: [{ target: "Todo", options: { as: "todos" } }],
+    belongsToMany: [{ target: "UserCategory", options: {} }],
+  }
+
+  const UserCategory: HatchifyModel = {
+    name: "UserCategory",
+    attributes: {
+      name: "STRING",
+    },
   }
 
   const Todo: HatchifyModel = {
@@ -31,7 +39,11 @@ describe("convertHatchifyModels", () => {
   }
 
   it("works", () => {
-    const models = convertHatchifyModels(sequelize, serializer, [Todo, User])
+    const models = convertHatchifyModels(sequelize, serializer, [
+      Todo,
+      User,
+      UserCategory,
+    ])
 
     expect(models).toEqual({
       associationsLookup: {
@@ -50,11 +62,19 @@ describe("convertHatchifyModels", () => {
             model: "Todo",
             type: "hasMany",
           },
+          userCategorys: {
+            joinTable: "UserUserCategory",
+            key: "usercategory_id",
+            model: "UserCategory",
+            type: "belongsToMany",
+          },
         },
       },
       models: {
         Todo: expect.any(Function),
         User: expect.any(Function),
+        UserCategory: expect.any(Function),
+        UserUserCategory: expect.any(Function),
       },
       virtuals: {},
     })

--- a/packages/node/src/sequelize/v1/convertHatchifyModels.ts
+++ b/packages/node/src/sequelize/v1/convertHatchifyModels.ts
@@ -119,10 +119,19 @@ export function convertHatchifyModels(
           const current = sequelize.models[model.name]
           const associated = sequelize.models[target]
 
+          const throughName =
+            model.name < target
+              ? `${model.name}${target}`
+              : `${target}${model.name}`
+
           // Create the relationship
           current[relationshipType](associated, {
             ...options,
             as: associationName,
+            through:
+              relationshipType === "belongsToMany"
+                ? options.through ?? throughName
+                : undefined,
           })
 
           // Add association details to a lookup for each model
@@ -134,7 +143,7 @@ export function convertHatchifyModels(
               relationshipType === "belongsToMany"
                 ? typeof options.through === "string"
                   ? options?.through
-                  : options?.through.model
+                  : options?.through?.model ?? throughName
                 : undefined,
           }
           associationsLookup[model.name] = {

--- a/packages/node/src/types/index.ts
+++ b/packages/node/src/types/index.ts
@@ -89,7 +89,8 @@ export type HatchifyAttributes = ModelAttributes<Model>
  */
 export interface BelongsToManyResult {
   target: string
-  options: BelongsToManyOptions
+  options: Omit<BelongsToManyOptions, "through"> &
+    Partial<Pick<BelongsToManyOptions, "through">>
 }
 
 /**


### PR DESCRIPTION
- naming.md specifies that the `through` property is optional and the name can be generated. Sequelize requires through, so a table name generator has been added.
- naming.md previously showed the through table name in snake_case in an example.  Convention is that it should be PascalCase.  The example has been updated.