### PR TITLE
HATCH-114: Remove subscribe re-export to end user

### DIFF
--- a/packages/react-jsonapi/src/react-jsonapi.test.ts
+++ b/packages/react-jsonapi/src/react-jsonapi.test.ts
@@ -50,8 +50,6 @@ describe("react-jsonapi", () =>
         useAll: expect.any(Function),
         useOne: expect.any(Function),
         useUpdateOne: expect.any(Function),
-        subscribeToAll: expect.any(Function),
-        subscribeToOne: expect.any(Function),
       },
       Person: {
         createOne: expect.any(Function),
@@ -64,8 +62,6 @@ describe("react-jsonapi", () =>
         useAll: expect.any(Function),
         useOne: expect.any(Function),
         useUpdateOne: expect.any(Function),
-        subscribeToAll: expect.any(Function),
-        subscribeToOne: expect.any(Function),
       },
     })
   }))

--- a/packages/react-rest/README.md
+++ b/packages/react-rest/README.md
@@ -19,7 +19,6 @@
     - [Fetching users and populating a select](#fetching-users-and-populating-a-select)
     - [Creating a todo with a user](#creating-a-todo-with-a-user)
 - [Alternatives to hooks](#alternatives-to-hooks)
-  - [Subscriptions](#subscriptions)
 
 <a id="what-is-react-rest?"></a>
 
@@ -804,7 +803,7 @@ For more information on react-rest, read on.
 
 ## Alternatives to hooks
 
-Sometimes we need to fetch data outside of our React components. For these cases, react-rest provides us with promise-based equivalents as well as subscribe functions for when we want to listen to any changes.
+Sometimes we need to fetch data outside of our React components. For these cases, react-rest provides us with promise-based equivalents.
 
 | hooks        | promises  |
 | ------------ | --------- |
@@ -813,23 +812,3 @@ Sometimes we need to fetch data outside of our React components. For these cases
 | useDeleteOne | deleteOne |
 | useAll       | findAll   |
 | useOne       | findOne   |
-
-<a id="subscriptions"></a>
-
-### Subscriptions
-
-To fire a callback whenever data is manipulated, you can use the subscribe functions:
-
-```ts
-const unsubscribe = hatchedReactRest.Todo.subscribeToAll(query, (data) => {
-  console.log("changes:", data)
-})
-```
-
-```ts
-const unsubscribe = hatchedReactRest.Todo.subscribeToOne(id, (data) => {
-  console.log("changes:", data)
-})
-```
-
-> **Note:** we named the return of the subscription method `unsubscribe` above because it's a function that can be called to do just that; i.e. `unsubscribe()`

--- a/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.test.ts
+++ b/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.test.ts
@@ -44,8 +44,6 @@ describe("react-rest/services/hatchifyReactRest", () => {
         useAll: expect.any(Function),
         useOne: expect.any(Function),
         useUpdateOne: expect.any(Function),
-        subscribeToAll: expect.any(Function),
-        subscribeToOne: expect.any(Function),
       },
       Person: {
         createOne: expect.any(Function),
@@ -58,8 +56,6 @@ describe("react-rest/services/hatchifyReactRest", () => {
         useAll: expect.any(Function),
         useOne: expect.any(Function),
         useUpdateOne: expect.any(Function),
-        subscribeToAll: expect.any(Function),
-        subscribeToOne: expect.any(Function),
       },
     })
   })
@@ -102,8 +98,6 @@ describe("react-rest/services/hatchifyReactRest", () => {
         useAll: expect.any(Function),
         useOne: expect.any(Function),
         useUpdateOne: expect.any(Function),
-        subscribeToAll: expect.any(Function),
-        subscribeToOne: expect.any(Function),
       },
       Person: {
         createOne: expect.any(Function),
@@ -116,8 +110,6 @@ describe("react-rest/services/hatchifyReactRest", () => {
         useAll: expect.any(Function),
         useOne: expect.any(Function),
         useUpdateOne: expect.any(Function),
-        subscribeToAll: expect.any(Function),
-        subscribeToOne: expect.any(Function),
       },
     })
   })

--- a/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
+++ b/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
@@ -4,8 +4,6 @@ import {
   deleteOne,
   findAll,
   findOne,
-  subscribeToAll,
-  subscribeToOne,
   transformSchema,
   updateOne,
 } from "@hatchifyjs/rest-client"
@@ -18,7 +16,6 @@ import type {
   QueryList,
   QueryOne,
   Record,
-  Unsubscribe,
   UpdateData,
   RequestMetaData,
 } from "@hatchifyjs/rest-client"
@@ -51,15 +48,6 @@ export type ReactRest<Schema extends SchemaRecord> = {
       Meta,
       Record | undefined | null,
     ]
-    // subscribes
-    subscribeToAll: (
-      query: QueryList | undefined,
-      callback: (data: Record[]) => void,
-    ) => Unsubscribe
-    subscribeToOne: (
-      id: string,
-      callback: (data: Record) => void,
-    ) => Unsubscribe
   }
 }
 
@@ -103,11 +91,6 @@ export function hatchifyReactRest<TSchemaRecord extends SchemaRecord>(
         useAll(dataSource, newSchemas, schema.name, query ?? {}),
       useOne: (query) => useOne(dataSource, newSchemas, schema.name, query),
       useUpdateOne: () => useUpdateOne(dataSource, newSchemas, schema.name),
-      // subscribes
-      subscribeToAll: (query, callback) =>
-        subscribeToAll(schema.name, query, callback),
-      subscribeToOne: (id, callback) =>
-        subscribeToOne(schema.name, id, callback),
     }
 
     return acc


### PR DESCRIPTION
- these are being hidden for now; they need to be reworked in a future sprint (hatch-366)