### PR TITLE
[HATCH-329] Full support for LIKE/ILIKE with ANY in Sqlite

### DIFF
--- a/packages/koa/src/queryStringFilters.spec.ts
+++ b/packages/koa/src/queryStringFilters.spec.ts
@@ -238,10 +238,6 @@ const testCases = [
     queryParam: "filter[onSite][$nin]=true&filter[manager][$nin]=true",
     expectedResult: [jane],
   },
-]
-
-const postgresOnlyTestCases = [
-  // TODO - we need to support this in SQLite too as part of HATCH-329
   {
     description:
       "returns correct data using the $ilike operator for an array of strings (non-case sensitive)",
@@ -252,41 +248,42 @@ const postgresOnlyTestCases = [
   },
 ]
 
+// const postgresOnlyTestCases: Array<{
+//   description: string
+//   operator: string
+//   queryParam: string
+//   expectedResult: typeof userData
+// }> = []
+
 // like not supported by SQLite
 const SQLiteOnlyTestCases = [
   {
     description:
-      "throws error when attempting to use the $like operator for end of a string",
+      "converts to regex when attempting to use the $like operator for end of a string",
     operator: "$like",
     queryParam: `filter[name][$like]=${encodeURIComponent("%ne")}`,
-    expectedErrorSource: {
-      parameter: `filter[name][$like]=${encodeURIComponent("%ne")}`,
-    },
+    expectedResult: [jane],
   },
   {
     description:
-      "throws error when attempting to use the $like operator for beginning of a string",
+      "converts to regex when attempting to use the $like operator for beginning of a string",
     operator: "$like",
     queryParam: `filter[name][$like]=${encodeURIComponent("Jo%")}`,
-    expectedErrorSource: {
-      parameter: `filter[name][$like]=${encodeURIComponent("Jo%")}`,
-    },
+    expectedResult: [john],
   },
   {
     description:
-      "throws error when attempting to use the $like operator for middle of a string",
+      "converts to regex when attempting to use the $like operator for middle of a string",
     operator: "$like",
     queryParam: `filter[name][$like]=${encodeURIComponent("%an%")}`,
-    expectedErrorSource: {
-      parameter: `filter[name][$like]=${encodeURIComponent("%an%")}`,
-    },
+    expectedResult: [jane],
   },
   {
     description:
-      "throws error when attempting to use the $like operator for entirety of a string (non-case sensitive)",
+      "converts to regex when attempting to use the $like operator for entirety of a string",
     operator: "$like",
     queryParam: "filter[name][$like]=John",
-    expectedErrorSource: { parameter: "filter[name][$like]=John" },
+    expectedResult: [john],
   },
 ]
 
@@ -345,50 +342,27 @@ describe.each(dbDialects)("queryStringFilters", (dialect) => {
     await teardown()
   })
 
-  it.each(testCases)(
-    `${dialect} - $description`,
-    async ({ expectedResult, queryParam }) => {
-      const { body } = await fetch(`/api/users/?${queryParam}`)
-      const users = body.data.map(({ attributes }) => attributes)
-      expect(users).toEqual(
-        expectedResult.map((er) => ({
-          ...er,
-          startDate: new Date(er.startDate).toISOString(),
-        })),
-      )
-    },
-  )
-
-  if (dialect === "postgres") {
-    it.each(postgresOnlyTestCases)(
-      `${dialect} - $description`,
-      async ({ expectedResult, queryParam }) => {
-        const { body } = await fetch(`/api/users/?${queryParam}`)
-        const users = body.data.map(({ attributes }) => attributes)
-        expect(users).toEqual(
-          expectedResult.map((er) => ({
-            ...er,
-            startDate: new Date(er.startDate).toISOString(),
-          })),
-        )
-      },
+  const validator = async ({ expectedResult, queryParam }) => {
+    const { body } = await fetch(`/api/users/?${queryParam}`)
+    if (body.errors) {
+      throw body.errors
+    }
+    const users = body.data.map(({ attributes }) => attributes)
+    expect(users).toEqual(
+      expectedResult.map((er) => ({
+        ...er,
+        startDate: new Date(er.startDate).toISOString(),
+      })),
     )
   }
 
+  it.each(testCases)(`${dialect} - $description`, validator)
+
+  // if (dialect === "postgres") {
+  //   it.each(postgresOnlyTestCases)(`${dialect} - $description`, validator)
+  // }
+
   if (dialect === "sqlite") {
-    it.each(SQLiteOnlyTestCases)(
-      `${dialect} - $description`,
-      async ({ expectedErrorSource, queryParam }) => {
-        const result = await fetch(`/api/users/?${queryParam}`)
-        const error = JSON.parse(result.error.text)
-        expect(error.errors[0]).toEqual({
-          status: 422,
-          code: "invalid-parameter",
-          detail: "SQLITE does not support like. Please use ilike",
-          source: expectedErrorSource,
-          title: "SQLITE does not support like",
-        })
-      },
-    )
+    it.each(SQLiteOnlyTestCases)(`${dialect} - $description`, validator)
   }
 })

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -98,6 +98,18 @@ export class Hatchify {
     // Prepare the ORM instance and keep references to the different Models
     this._sequelize = createSequelizeInstance(options.database)
 
+    if (this._sequelize.getDialect() === "sqlite") {
+      const gc = this._sequelize.connectionManager.getConnection
+      this._sequelize.connectionManager.getConnection = async function (
+        ...args: Parameters<typeof gc>
+      ) {
+        // const { getLoadablePath } = await import("sqlite-regex")
+        const db = await gc.apply(this, args)
+        // db.loadExtension(getLoadablePath())
+        db.run("PRAGMA case_sensitive_like=ON")
+        return db
+      }
+    }
     this._serializer = new JSONAPISerializer()
 
     // Fetch the hatchify models and associations look up

--- a/packages/node/src/parse/builder.spec.ts
+++ b/packages/node/src/parse/builder.spec.ts
@@ -187,6 +187,116 @@ describe("builder", () => {
         }),
       ])
     })
+
+    it("does not convert LIKE for Sqlite", async () => {
+      const options = buildFindOptions(
+        hatchify,
+        Todo,
+        "filter[name][$like]=test%25",
+      )
+
+      expect(options).toEqual({
+        data: {
+          where: { name: { [Op.like]: "test%" } },
+        },
+        errors: [],
+        orm: "sequelize",
+      })
+    })
+
+    it("converts LIKE ANY for Sqlite", async () => {
+      const options = buildFindOptions(
+        hatchify,
+        Todo,
+        "filter[name][$like]=test,foo",
+      )
+
+      expect(options).toEqual({
+        data: {
+          where: {
+            name: {
+              [Op.or]: [{ [Op.like]: "test" }, { [Op.like]: "foo" }],
+            },
+          },
+        },
+        errors: [],
+        orm: "sequelize",
+      })
+    })
+
+    it("converts ILIKE for Sqlite", async () => {
+      const options = buildFindOptions(
+        hatchify,
+        Todo,
+        "filter[name][$ilike]=test",
+      )
+
+      expect(options).toEqual({
+        data: {
+          where: {
+            [Op.and]: [
+              {
+                attribute: {
+                  args: [
+                    {
+                      col: "name",
+                    },
+                  ],
+                  fn: "upper",
+                },
+                comparator: Op.like,
+                logic: "TEST",
+              },
+            ],
+          },
+        },
+        errors: [],
+        orm: "sequelize",
+      })
+    })
+
+    it("converts ILIKE ANY for Sqlite", async () => {
+      const options = buildFindOptions(
+        hatchify,
+        Todo,
+        "filter[name][$ilike]=test,foo",
+      )
+
+      expect(options).toEqual({
+        data: {
+          where: {
+            [Op.or]: [
+              {
+                attribute: {
+                  args: [
+                    {
+                      col: "name",
+                    },
+                  ],
+                  fn: "upper",
+                },
+                comparator: Op.like,
+                logic: "TEST",
+              },
+              {
+                attribute: {
+                  args: [
+                    {
+                      col: "name",
+                    },
+                  ],
+                  fn: "upper",
+                },
+                comparator: Op.like,
+                logic: "FOO",
+              },
+            ],
+          },
+        },
+        errors: [],
+        orm: "sequelize",
+      })
+    })
   })
 
   describe("buildCreateOptions", () => {

--- a/packages/node/src/parse/builder.ts
+++ b/packages/node/src/parse/builder.ts
@@ -8,9 +8,9 @@ import type {
   Identifier,
   UpdateOptions,
 } from "sequelize"
+import { Op, Sequelize } from "sequelize"
 
-import { HatchifyError, UnexpectedValueError } from "../error"
-import { codes, statusCodes } from "../error/constants"
+import { UnexpectedValueError } from "../error"
 import type { Hatchify } from "../node"
 import type { HatchifyModel } from "../types"
 
@@ -20,27 +20,117 @@ interface QueryStringParser<T> {
   orm: "sequelize"
 }
 
-function handleSqliteLike(querystring: string, dbType: string): string {
+function handleSqliteLike(
+  ops: QueryStringParser<FindOptions>,
+  dbType: string,
+): QueryStringParser<FindOptions> {
   // if not postgres (sqlite)
   // 1. throw error if like is used (temporary)
   // 2. ilike needs to be changed to like before parsing query
   // 3. TODO - HATCH-329 if query includes an array, it needs to be changed to an OR query
   // (sqlite doesn't support Op.any like postgres)
-  if (dbType === "sqlite") {
-    if (querystring.includes("[$like]")) {
-      throw new HatchifyError({
-        code: codes.ERR_INVALID_PARAMETER,
-        title: "SQLITE does not support like",
-        status: statusCodes.UNPROCESSABLE_ENTITY,
-        detail: "SQLITE does not support like. Please use ilike",
-        parameter: querystring,
-      })
+  //
+  ///if (key === Op.like)
+  ///
+  const walk: <T>(
+    maybeObj: T | any[],
+    fn: (key: string | symbol, value: unknown) => void,
+  ) => T | any[] = (maybeObj, fn) => {
+    if (Array.isArray(maybeObj)) {
+      return maybeObj.map((item) => walk<typeof item>(item, fn))
+    } else if (maybeObj && typeof maybeObj === "object") {
+      const keys = [
+        ...Object.getOwnPropertyNames(maybeObj),
+        ...Object.getOwnPropertySymbols(maybeObj),
+      ]
+      const entries = keys.map((k) => [k, maybeObj[k]])
+      return entries.reduce((acc, [key, value]) => {
+        const [newVal, newKey = key] =
+          (fn(key, value) as unknown as [unknown, string | symbol]) ?? []
+        return {
+          ...acc,
+          [newKey]: newVal ?? walk<typeof value>(value, fn),
+        }
+      }, {}) as typeof maybeObj
+    } else {
+      return maybeObj
     }
-
-    return querystring.replaceAll("[$ilike]", "[$like]")
   }
 
-  return querystring
+  // const reEscape = (str) =>
+  //   `^${str.replace(/([[\]()^$*+{}.])/g, "\\$1").replace(/%/g, ".*")}$`
+
+  if (dbType === "sqlite") {
+    ops.data.where = walk<typeof ops.data.where>(
+      ops.data.where,
+      (key, value) => {
+        if (key === Op.like) {
+          // PostgreSQL has a LIKE ANY clause but SQLite does not understand
+          // the ANY part.  For LIKE ANY, convert to an OR of LIKEs.
+          if (value && typeof value === "object" && Op.any in value) {
+            return [
+              (value[Op.any] as string[]).map((token) => ({
+                [Op.like]: token,
+              })),
+              Op.or,
+            ]
+            // Was previously trying to implement these clauses as regex instead,
+            // but the regex plugin is unstable (at least on Darwin x64) and
+            // wouldn't complete the tests without segfaulting.
+            // return [
+            //   (value[Op.any] as string[]).map(reEscape).join("|"),
+            //   Op.regexp,
+            // ]
+          } else {
+            // If not LIKE ANY, i.e. just LIKE, no transform is necessary
+            return [value, key]
+            // return [reEscape(value as string), Op.regexp]
+          }
+        }
+        // SQLite does not have an ILIKE operator.  At DB connection time
+        // we set a PRAGMA to make LIKE case sensitive (it is case insensitive
+        // by default) so LIKE is normal but ILIKE must be implemented as
+        //   LIKE UPPER(col) = value.toUpperCase()
+        // The implementation comes from a special Sequelize consructor to
+        // create a WHERE clause or sub-clause with a function call on a column
+        // (first arg), an operator (second arg), and a simple string expression
+        // (third arg).
+        if (typeof key === "string" && Op.iLike in (value as any)) {
+          const ilClause = (value as { [Op.iLike]: any })[Op.iLike]
+          if (ilClause && typeof ilClause === "object" && Op.any in ilClause) {
+            // S
+            return [
+              // could also do a regex if the regex extension worked,
+              //   like above regex example but prefix regex with (?i)
+              (ilClause[Op.any] as string[]).map((token) =>
+                Sequelize.where(
+                  Sequelize.fn("upper", Sequelize.col(key)),
+                  Op.like,
+                  (token as string).toUpperCase(),
+                ),
+              ),
+              Op.or,
+            ]
+          } else {
+            // Because of how we're walking the original object it's hard
+            // to replace a keyed object property with a WHERE.  For
+            // convenience, an ILIKE on SQLite is structured as
+            //    { [Op.and]: [<where clause with upper()>] }
+            // because Op.and is expected to be an array but if the array is
+            // length 1 then the actual SQL can discard using any ANDs
+            const token = Sequelize.where(
+              Sequelize.fn("upper", Sequelize.col(key)),
+              Op.like,
+              (ilClause as string).toUpperCase(),
+            )
+            return [[token], Op.and]
+          }
+        }
+        return
+      },
+    )
+  }
+  return ops
 }
 
 export function buildFindOptions(
@@ -49,8 +139,9 @@ export function buildFindOptions(
   querystring: string,
   id?: Identifier,
 ): QueryStringParser<FindOptions> {
-  const ops: QueryStringParser<FindOptions> = querystringParser.parse(
-    handleSqliteLike(querystring, hatchify.orm.getDialect()),
+  const ops: QueryStringParser<FindOptions> = handleSqliteLike(
+    querystringParser.parse(querystring),
+    hatchify.orm.getDialect(),
   )
 
   if (ops.errors.length) {


### PR DESCRIPTION
This PR overrides getConnection() in Sequelize's Sqlite connection manager to add the PRAGMA statement for case-sensitive LIKE.  Additionally, the query rewriter in builder.js has been completely rewritten to happen _after_ the Sequelize query object has been constructed.  It recursively walks the where clause tree looking for Op.like and Op.ilike, and rewrites them according to these rules:
* LIKE without ANY is not modified
* LIKE with AND is rewritten to an OR clause of LIKE statements for each item in the original ANY clause
* ILIKE without ANY is rewritten to a Sequelize Where object comparing the UPPER() of the column value to the uppercased search string (along with an AND 1 because it makes implementation easier)
* ILIKE with ANY is rewritten to an OR clause of WHERE objects comparing the UPPER() of the column value to the uppercased version of each item in the original ANY clause