### PR TITLE
Hatch 326 - namespace short format in fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17051,11 +17051,11 @@
     },
     "packages/design-mui": {
       "name": "@hatchifyjs/design-mui",
-      "version": "0.0.1-34",
+      "version": "0.0.1-36",
       "dependencies": {
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
-        "@hatchifyjs/react-ui": "^0.0.1-25",
+        "@hatchifyjs/react-ui": "^0.0.1-27",
         "@mui/icons-material": "^5.14.1",
         "@mui/material": "^5.12.0",
         "@mui/utils": "^5.13.1"
@@ -17220,12 +17220,12 @@
     },
     "packages/react": {
       "name": "@hatchifyjs/react",
-      "version": "0.0.1-41",
+      "version": "0.0.1-43",
       "dependencies": {
-        "@hatchifyjs/design-mui": "^0.0.1-34",
+        "@hatchifyjs/design-mui": "^0.0.1-36",
         "@hatchifyjs/hatchify-core": "^0.1.0",
-        "@hatchifyjs/react-ui": "^0.0.1-25",
-        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-24"
+        "@hatchifyjs/react-ui": "^0.0.1-27",
+        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-26"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -17243,10 +17243,10 @@
     },
     "packages/react-jsonapi": {
       "name": "@hatchifyjs/react-jsonapi",
-      "version": "0.0.1-23",
+      "version": "0.0.1-25",
       "dependencies": {
-        "@hatchifyjs/react-rest": "^0.0.1-21",
-        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-24"
+        "@hatchifyjs/react-rest": "^0.0.1-23",
+        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-26"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -17259,10 +17259,10 @@
     },
     "packages/react-rest": {
       "name": "@hatchifyjs/react-rest",
-      "version": "0.0.1-21",
+      "version": "0.0.1-23",
       "dependencies": {
         "@hatchifyjs/hatchify-core": "^0.1.0",
-        "@hatchifyjs/rest-client": "^0.0.1-16"
+        "@hatchifyjs/rest-client": "^0.0.1-17"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -17280,11 +17280,11 @@
     },
     "packages/react-ui": {
       "name": "@hatchifyjs/react-ui",
-      "version": "0.0.1-25",
+      "version": "0.0.1-27",
       "dependencies": {
         "@hatchifyjs/hatchify-core": "^0.1.0",
-        "@hatchifyjs/react-rest": "^0.0.1-21",
-        "@hatchifyjs/rest-client": "^0.0.1-16",
+        "@hatchifyjs/react-rest": "^0.0.1-23",
+        "@hatchifyjs/rest-client": "^0.0.1-17",
         "lodash": "^4.17.21",
         "uuid": "^9.0.0"
       },
@@ -17315,7 +17315,7 @@
     },
     "packages/rest-client": {
       "name": "@hatchifyjs/rest-client",
-      "version": "0.0.1-16",
+      "version": "0.0.1-17",
       "dependencies": {
         "@hatchifyjs/hatchify-core": "^0.1.0"
       },
@@ -17328,13 +17328,13 @@
     },
     "packages/rest-client-jsonapi": {
       "name": "@hatchifyjs/rest-client-jsonapi",
-      "version": "0.0.1-24",
+      "version": "0.0.1-26",
       "dependencies": {
-        "@hatchifyjs/rest-client": "^0.0.1-16"
+        "@hatchifyjs/rest-client": "^0.0.1-17"
       },
       "devDependencies": {
         "@hatchifyjs/koa": "^0.1.3",
-        "@hatchifyjs/react-rest": "^0.0.1-20",
+        "@hatchifyjs/react-rest": "^0.0.1-23",
         "@koa/cors": "^4.0.0",
         "@types/koa__cors": "^4.0.0",
         "@vitest/coverage-c8": "^0.32.2",
@@ -18322,7 +18322,7 @@
       "requires": {
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
-        "@hatchifyjs/react-ui": "^0.0.1-25",
+        "@hatchifyjs/react-ui": "^0.0.1-27",
         "@hatchifyjs/rest-client": "^0.0.1-16",
         "@mui/icons-material": "^5.14.1",
         "@mui/material": "^5.12.0",
@@ -18448,10 +18448,10 @@
     "@hatchifyjs/react": {
       "version": "file:packages/react",
       "requires": {
-        "@hatchifyjs/design-mui": "^0.0.1-34",
+        "@hatchifyjs/design-mui": "^0.0.1-36",
         "@hatchifyjs/hatchify-core": "^0.1.0",
-        "@hatchifyjs/react-ui": "^0.0.1-25",
-        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-24",
+        "@hatchifyjs/react-ui": "^0.0.1-27",
+        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-26",
         "@types/react": "^18.2.0",
         "@vitejs/plugin-react": "^4.0.0",
         "@vitest/coverage-c8": "^0.32.2",
@@ -18464,8 +18464,8 @@
     "@hatchifyjs/react-jsonapi": {
       "version": "file:packages/react-jsonapi",
       "requires": {
-        "@hatchifyjs/react-rest": "^0.0.1-21",
-        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-24",
+        "@hatchifyjs/react-rest": "^0.0.1-23",
+        "@hatchifyjs/rest-client-jsonapi": "^0.0.1-26",
         "@types/react": "^18.2.0",
         "@vitejs/plugin-react": "^4.0.0",
         "@vitest/coverage-c8": "^0.32.2",
@@ -18478,7 +18478,7 @@
       "version": "file:packages/react-rest",
       "requires": {
         "@hatchifyjs/hatchify-core": "^0.1.0",
-        "@hatchifyjs/rest-client": "^0.0.1-16",
+        "@hatchifyjs/rest-client": "^0.0.1-17",
         "@testing-library/react": "^14.0.0",
         "@types/react": "^18.2.0",
         "@vitest/coverage-c8": "^0.32.2",
@@ -18492,8 +18492,8 @@
       "version": "file:packages/react-ui",
       "requires": {
         "@hatchifyjs/hatchify-core": "^0.1.0",
-        "@hatchifyjs/react-rest": "^0.0.1-21",
-        "@hatchifyjs/rest-client": "^0.0.1-16",
+        "@hatchifyjs/react-rest": "^0.0.1-23",
+        "@hatchifyjs/rest-client": "^0.0.1-17",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@types/lodash": "^4.14.192",
@@ -18527,8 +18527,8 @@
       "version": "file:packages/rest-client-jsonapi",
       "requires": {
         "@hatchifyjs/koa": "^0.1.3",
-        "@hatchifyjs/react-rest": "^0.0.1-20",
-        "@hatchifyjs/rest-client": "^0.0.1-16",
+        "@hatchifyjs/react-rest": "^0.0.1-23",
+        "@hatchifyjs/rest-client": "^0.0.1-17",
         "@koa/cors": "^4.0.0",
         "@types/koa__cors": "^4.0.0",
         "@vitest/coverage-c8": "^0.32.2",

--- a/packages/koa/src/jsonapiNamespace.spec.ts
+++ b/packages/koa/src/jsonapiNamespace.spec.ts
@@ -120,5 +120,15 @@ describe("JSON:API Tests", () => {
     expect(hasNamespace).toBeTruthy()
     expect(hasNamespace.status).toBe(200)
     expect(namespaceless).toStrictEqual(hasNamespace)
+
+    // make sure the response have only the requested fields
+    namespaceless.deserialized.forEach((record: any) => {
+      expect(record).toHaveProperty("first_name")
+      expect(record).not.toHaveProperty("last_name")
+    })
+    hasNamespace.deserialized.forEach((record: any) => {
+      expect(record).toHaveProperty("first_name")
+      expect(record).not.toHaveProperty("last_name")
+    })
   })
 })

--- a/packages/koa/src/jsonapiNamespace.spec.ts
+++ b/packages/koa/src/jsonapiNamespace.spec.ts
@@ -109,13 +109,13 @@ describe("JSON:API Tests", () => {
 
     const namespaceless = await GET(
       server,
-      "/api/test-schema/models?fields[Model]=first_name,last_name",
+      "/api/test-schema/models?fields[Model]=first_name",
     )
     expect(namespaceless).toBeTruthy()
     expect(namespaceless.status).toBe(200)
     const hasNamespace = await GET(
       server,
-      "/api/test-schema/models?fields[TestSchema.Model]=first_name,last_name",
+      "/api/test-schema/models?fields[TestSchema.Model]=first_name",
     )
     expect(hasNamespace).toBeTruthy()
     expect(hasNamespace.status).toBe(200)

--- a/packages/koa/src/jsonapiNamespace.spec.ts
+++ b/packages/koa/src/jsonapiNamespace.spec.ts
@@ -111,12 +111,14 @@ describe("JSON:API Tests", () => {
       server,
       "/api/test-schema/models?fields[Model]=first_name,last_name",
     )
-
+    expect(namespaceless).toBeTruthy()
+    expect(namespaceless.status).toBe(200)
     const hasNamespace = await GET(
       server,
       "/api/test-schema/models?fields[TestSchema.Model]=first_name,last_name",
     )
-
+    expect(hasNamespace).toBeTruthy()
+    expect(hasNamespace.status).toBe(200)
     expect(namespaceless).toStrictEqual(hasNamespace)
   })
 })

--- a/packages/koa/src/jsonapiNamespace.spec.ts
+++ b/packages/koa/src/jsonapiNamespace.spec.ts
@@ -1,3 +1,4 @@
+import { Server } from "http"
 import { DataTypes } from "@hatchifyjs/node"
 import type { HatchifyModel } from "@hatchifyjs/node"
 import { Serializer } from "jsonapi-serializer"
@@ -7,6 +8,7 @@ import { Hatchify } from "./koa"
 import { GET, POST, createServer } from "./testing/utils"
 
 describe("JSON:API Tests", () => {
+  let app: Koa, hatchify: Hatchify, server: Server
   const Model: HatchifyModel = {
     name: "Model",
     namespace: "TestSchema",
@@ -32,14 +34,21 @@ describe("JSON:API Tests", () => {
     return serial
   }
 
-  it("should handle JSON:API create body", async () => {
-    const app = new Koa()
-    const hatchify = new Hatchify([Model], { prefix: "/api" })
+  beforeAll(async () => {
+    app = new Koa()
+    hatchify = new Hatchify([Model], { prefix: "/api" })
     app.use(hatchify.middleware.allModels.all)
 
-    const server = createServer(app)
+    server = createServer(app)
     await hatchify.createDatabase()
+  })
 
+  afterAll(async () => {
+    await hatchify.orm.close()
+    await server.close()
+  })
+
+  it("should handle JSON:API create body", async () => {
     //JK will separate cases into different it() tests
     const r1 = await POST(
       server,
@@ -81,7 +90,32 @@ describe("JSON:API Tests", () => {
     expect(find.status).toBe(200)
     expect(find.deserialized).toBeTruthy()
     expect(find.deserialized.id).toBe(r2.deserialized.id)
+  })
 
-    await hatchify.orm.close()
+  it("should be able to omit namespace when referring to fields that belongs to the same namespace", async () => {
+    const r1 = await POST(
+      server,
+      "/api/testschema.models",
+      serialize({
+        first_name: "firstName",
+        last_name: "lastName",
+        type: "TestSchema.Model",
+      }),
+      "application/vnd.api+json",
+    )
+    expect(r1).toBeTruthy()
+    expect(r1.status).toBe(200)
+
+    const namespaceless = await GET(
+      server,
+      "/api/test-schema/models?fields[Model]=first_name,last_name",
+    )
+
+    const hasNamespace = await GET(
+      server,
+      "/api/test-schema/models?fields[TestSchema.Model]=first_name,last_name",
+    )
+
+    expect(namespaceless).toStrictEqual(hasNamespace)
   })
 })

--- a/packages/koa/src/jsonapiNamespace.spec.ts
+++ b/packages/koa/src/jsonapiNamespace.spec.ts
@@ -1,4 +1,5 @@
-import { Server } from "http"
+import type { Server } from "http"
+
 import { DataTypes } from "@hatchifyjs/node"
 import type { HatchifyModel } from "@hatchifyjs/node"
 import { Serializer } from "jsonapi-serializer"


### PR DESCRIPTION
For Hatch 326

Adding a test to check that querying model fields in the same namespace using short format is working as expected.