### PR TITLE
HATCH-375 document string() and boolean() query string behavior

### DIFF
--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -79,4 +79,4 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[complete][$eq]=\x00` where `\x00` represents the encoded `null` value.
+`filter[complete][$eq]=%00` where `%00` represents the encoded `null` value, or `filter[complete][$eq]=null`.

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -7,15 +7,14 @@ export const Todo: PartialSchema = {
   name: "Todo",
   attributes: {
     complete: boolean({ required: true }),
-  }
+  },
 }
 ```
 
 ## Parameters
 
-- `default` [{Boolean}] - The default value of the attribute.  Example: `boolean({default: true})`
+- `default` [{Boolean}] - The default value of the attribute. Example: `boolean({default: true})`
 - `required` [{Boolean=false}] - If the attribute must be provided.
-
 
 ## Database and Sequelize Behavior
 
@@ -37,7 +36,6 @@ Any other value will return a service error.
 
 Checkout the [compatibility table](../filtering-data/filtering-data.md#compatibility) for what operators can be used with booleans.
 
-
 ### Data Response
 
 Boolean data will be returned as `true`, `false`, or `null` as follows:
@@ -53,19 +51,18 @@ Boolean data will be returned as `true`, `false`, or `null` as follows:
 }
 ```
 
-
 ### Mutating Data
 
 When creating or updating a boolean attribute, `true`, `false`, or `null` must be provided. Any other value will return a service error.
 
 ## React Rest Behavior
 
-Similar to the middleware, you MUST provide react rest models a `true`, `false`, or `null` value.  Likewise, they will always return these values:
+Similar to the middleware, you MUST provide react rest models a `true`, `false`, or `null` value. Likewise, they will always return these values:
 
 ```ts
-Todo.createOne({attributes: {complete: true}});
+Todo.createOne({ attributes: { complete: true } })
 
-const [todo, todoMeta] = hatchedReactRest.Todo.useOne({id})
+const [todo, todoMeta] = hatchedReactRest.Todo.useOne({ id })
 todo.complete //-> true, false or null
 ```
 
@@ -75,13 +72,11 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 
 ![Grid Example](https://github.com/bitovi/hatchify/assets/78602/ddbf26a1-180b-4fc7-a483-fde52dc4fce9)
 
-
 ## Form Behavior
 
 `boolean()` will produce a [`<input type=checkbox>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox) control. `null` will be treated as unchecked.
 
+## Filtering
 
-
-
-
-
+If `required` is `false`, filtering `null` values can is handled like the following:
+`filter[complete][$eq]=\x00` where `\x00` represents the encoded `null` value

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -79,4 +79,6 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[complete][$eq]=%00` where `%00` represents the encoded `null` value, or `filter[complete][$eq]=null`.
+
+- `filter[name][$eq]=%00` will filter records where name is absent.
+- `filter[name][$eq]=null` will filter records where name equals the string `null`.

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -78,7 +78,15 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 
 ## Query string behavior 🛑
 
+### Parameters
+
 If `required` is `false`, filtering `null` values is handled like the following:
 
 - `filter[complete][$eq]=%00` will filter records where `complete` is absent.
 - `filter[complete][$eq]=null` will filter records where `complete` equals the string `null`.
+
+### Middleware Behavior 🛑
+
+#### Querying Behavior 🛑
+
+Query string is escaped using `querystring.escape` to make sure that the SQL query is built correctly.

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -83,7 +83,7 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 If `required` is `false`, filtering `null` values is handled like the following:
 
 - `filter[complete][$eq]=%00` will filter records where `complete` is absent.
-- `filter[complete][$eq]=null` will filter records where `complete` equals the string `null`.
+- `filter[complete][$eq]=null` will filter records where `complete` equals `null`.
 
 ### Middleware Behavior 🛑
 

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -76,7 +76,7 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 
 `boolean()` will produce a [`<input type=checkbox>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox) control. `null` will be treated as unchecked.
 
-## Filtering
+## Query string behavior
 
-If `required` is `false`, filtering `null` values can is handled like the following:
+If `required` is `false`, filtering `null` values is handled like the following:
 `filter[complete][$eq]=\x00` where `\x00` represents the encoded `null` value

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -76,9 +76,9 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 
 `boolean()` will produce a [`<input type=checkbox>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox) control. `null` will be treated as unchecked.
 
-## Query string behavior
+## Query string behavior 🛑
 
 If `required` is `false`, filtering `null` values is handled like the following:
 
-- `filter[name][$eq]=%00` will filter records where name is absent.
-- `filter[name][$eq]=null` will filter records where name equals the string `null`.
+- `filter[complete][$eq]=%00` will filter records where `complete` is absent.
+- `filter[complete][$eq]=null` will filter records where `complete` equals the string `null`.

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -24,11 +24,11 @@ The `boolean` type will create a sequelize [DataTypes.BOOLEAN](https://sequelize
 
 ### Querying Data
 
-For booleans, use `true`, `false`, and `null` in your queries as follows:
+For booleans, use `true`, `false`, and `%00` in your queries as follows:
 
 ```js
 GET /todos?complete=true  // all complete todos
-GET /todos?complete=null  // all todos with null as the complete value
+GET /todos?complete=%00  // all todos with null as the complete value 🛑
 GET /todos?complete=false // all false todos
 ```
 
@@ -75,18 +75,3 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 ## Form Behavior
 
 `boolean()` will produce a [`<input type=checkbox>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox) control. `null` will be treated as unchecked.
-
-## Query string behavior 🛑
-
-### Parameters
-
-If `required` is `false`, filtering `null` values is handled like the following:
-
-- `filter[complete][$eq]=%00` will filter records where `complete` is absent.
-- `filter[complete][$eq]=null` will filter records where `complete` equals `null`.
-
-### Middleware Behavior 🛑
-
-#### Querying Behavior 🛑
-
-Query string is escaped using `querystring.escape` to make sure that the SQL query is built correctly.

--- a/doc/attribute-types/boolean.md
+++ b/doc/attribute-types/boolean.md
@@ -79,4 +79,4 @@ The text `true` or `false` will be presented in the grid. If the value is `null`
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[complete][$eq]=\x00` where `\x00` represents the encoded `null` value
+`filter[complete][$eq]=\x00` where `\x00` represents the encoded `null` value.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -30,4 +30,4 @@ If `required` is `false`, empty strings will be treated as `null` values.
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[name][$eq]=\x00` where `\x00` represents the encoded `null` value.
+`filter[complete][$eq]=%00` where `%00` represents the encoded `null` value, or `filter[complete][$eq]=null`.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -7,31 +7,27 @@ export const Todo: PartialSchema = {
   name: "Todo",
   attributes: {
     name: string({ required: true }),
-  }
+  },
 }
 ```
 
 ## Parameters
 
-- `default` [{String}] - The default value of the attribute.  Example: `string({default: "USA"})`
+- `default` [{String}] - The default value of the attribute. Example: `string({default: "USA"})`
 - `max` [{Number=225}] - The maximum number of characters allowed. Defaults to 255. Example: `string({max: 1023})`
-- `min` [{Number=0}] - The minimum number of characters allowed.  Defaults to 0. Example: `string({min: 1})`
+- `min` [{Number=0}] - The minimum number of characters allowed. Defaults to 0. Example: `string({min: 1})`
 - `references` - [See References]()
 - `required` [{Boolean=false}] - If the attribute must be provided.
 
-
-
 ## Form Controls
 
-`string()` with `max` of 255 and less will produce a standard text input like: `<input type=text>`. 
+`string()` with `max` of 255 and less will produce a standard text input like: `<input type=text>`.
 
-`string()` with `max` of 256 and more will show a : `<textarea>`. 
+`string()` with `max` of 256 and more will show a : `<textarea>`.
 
 If `required` is `false`, empty strings will be treated as `null` values.
 
+## Query string behavior
 
-
-
-
-
-
+If `required` is `false`, filtering `null` values can is handled like the following:
+`filter[name][$eq]=\0xx` where `\x00` represents the encoded `null` value

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -11,6 +11,35 @@ export const Todo: PartialSchema = {
 }
 ```
 
+## Querying Data
+
+If `required` is `false`, filtering `null` values is handled like the following:
+
+```
+GET /todos?name=foo  // all todos with name foo
+GET /todos?name=%00  // all todos with null as the name value 🛑
+GET /todos?name=null  // all todos with "null" as the name value
+```
+
+### Data Response
+
+String data will be returned as a string value or `null` as follows:
+
+```js
+{
+  data: {
+    ...
+    attributes: {
+      name: "foo" // or null
+    }
+  }
+}
+```
+
+### Mutating Data
+
+When creating or updating a string attribute, string value or `null` must be provided. Any other value will return a service error.
+
 ## Parameters
 
 - `default` [{String}] - The default value of the attribute. Example: `string({default: "USA"})`
@@ -26,18 +55,3 @@ export const Todo: PartialSchema = {
 `string()` with `max` of 256 and more will show a : `<textarea>`.
 
 If `required` is `false`, empty strings will be treated as `null` values.
-
-## Query string behavior 🛑
-
-### Parameters
-
-If `required` is `false`, filtering `null` values is handled like the following:
-
-- `filter[name][$eq]=%00` will filter records where `name` is absent.
-- `filter[name][$eq]=null` will filter records where `name` equals the string `null`.
-
-### Middleware Behavior 🛑
-
-#### Querying Behavior 🛑
-
-Query string is escaped using `querystring.escape` to make sure that the SQL query is built correctly.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -30,4 +30,4 @@ If `required` is `false`, empty strings will be treated as `null` values.
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[name][$eq]=\0xx` where `\x00` represents the encoded `null` value
+`filter[name][$eq]=\0xx` where `\x00` represents the encoded `null` value.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -29,5 +29,5 @@ If `required` is `false`, empty strings will be treated as `null` values.
 
 ## Query string behavior
 
-If `required` is `false`, filtering `null` values can is handled like the following:
+If `required` is `false`, filtering `null` values is handled like the following:
 `filter[name][$eq]=\0xx` where `\x00` represents the encoded `null` value

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -19,6 +19,8 @@ If `required` is `false`, filtering `null` values is handled like the following:
 GET /todos?name=foo  // all todos with name foo
 GET /todos?name=%00  // all todos with null as the name value 🛑
 GET /todos?name=null  // all todos with "null" as the name value
+GET /todos?name=  // all todos with "" as the name value
+GET /todos?name=undefined  // all todos with "undefined" as the name value
 ```
 
 ### Data Response

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -27,9 +27,9 @@ export const Todo: PartialSchema = {
 
 If `required` is `false`, empty strings will be treated as `null` values.
 
-## Query string behavior
+## Query string behavior 🛑
 
 If `required` is `false`, filtering `null` values is handled like the following:
 
-- `filter[name][$eq]=%00` will filter records where name is absent.
-- `filter[name][$eq]=null` will filter records where name equals the string `null`.
+- `filter[name][$eq]=%00` will filter records where `name` is absent.
+- `filter[name][$eq]=null` will filter records where `name` equals the string `null`.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -29,7 +29,15 @@ If `required` is `false`, empty strings will be treated as `null` values.
 
 ## Query string behavior 🛑
 
+### Parameters
+
 If `required` is `false`, filtering `null` values is handled like the following:
 
 - `filter[name][$eq]=%00` will filter records where `name` is absent.
 - `filter[name][$eq]=null` will filter records where `name` equals the string `null`.
+
+### Middleware Behavior 🛑
+
+#### Querying Behavior 🛑
+
+Query string is escaped using `querystring.escape` to make sure that the SQL query is built correctly.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -30,4 +30,6 @@ If `required` is `false`, empty strings will be treated as `null` values.
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[complete][$eq]=%00` where `%00` represents the encoded `null` value, or `filter[complete][$eq]=null`.
+
+- `filter[name][$eq]=%00` will filter records where name is absent.
+- `filter[name][$eq]=null` will filter records where name equals the string `null`.

--- a/doc/attribute-types/string.md
+++ b/doc/attribute-types/string.md
@@ -30,4 +30,4 @@ If `required` is `false`, empty strings will be treated as `null` values.
 ## Query string behavior
 
 If `required` is `false`, filtering `null` values is handled like the following:
-`filter[name][$eq]=\0xx` where `\x00` represents the encoded `null` value.
+`filter[name][$eq]=\x00` where `\x00` represents the encoded `null` value.


### PR DESCRIPTION
<!-- The title of the PR should contain the ticket number and one line summary, ie HATCHXXX-1234: Ticket summary -->
<!-- For multiple tickets include multiple ticket numbers, ie HATCHXXX-1234, 4567: Summary of tickets -->

# Description

Adds documentations for query string behavior for both `string()` and `boolean()` .

# Jira ticket links

https://bitovi.atlassian.net/browse/HATCH-375

# Test Plan

This is just documentation part.

# Definition of done

- [x] Document the needed behaviors.
- [x] Verify using \x00 is actually parsed and understood by node correctly.