### PR TITLE
[HATCH-380] add validations for correct includes when sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -830,20 +830,20 @@
       }
     },
     "node_modules/@bitovi/querystring-parser": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.7.7.tgz",
-      "integrity": "sha512-bSY+r/z2gGV3HYeipPY2kQVhthUwjPAUiFInIf4pyQ955Be1QjU4qtjBDqVM5V5GD7gigOcFGrAeksndi+R9CQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.7.8.tgz",
+      "integrity": "sha512-QLP18EA/yA3oGnFTXn6iRtVVmJ6yw/nySVRF9PV2+/1hOG7Ehds2Z55WNJliL65ge7HQytxf+gjc0ekVCUYMRQ==",
       "dependencies": {
         "qs": "^6.10.3",
         "sequelize": "^6.21.2"
       }
     },
     "node_modules/@bitovi/sequelize-querystring-parser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@bitovi/sequelize-querystring-parser/-/sequelize-querystring-parser-0.2.7.tgz",
-      "integrity": "sha512-9zdZSWVNTEXjWHkuJo2EoFX0FTVqRVEZ2gewxyzNDR6On2yTgcHcb08YcnuCnz7cln5kgs5+HladvvamL9dSRQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@bitovi/sequelize-querystring-parser/-/sequelize-querystring-parser-0.2.8.tgz",
+      "integrity": "sha512-Iib10tJd0e7sah1qVk/yZCXfXFU66H/ruIIpT7f8U5ONCUt1LRuPxDJQytXzIQi36o9uC+YBArDXZVEpSK0B6w==",
       "dependencies": {
-        "@bitovi/querystring-parser": "^0.7.7",
+        "@bitovi/querystring-parser": "^0.7.8",
         "sequelize": "^6.21.2"
       }
     },
@@ -1536,9 +1536,9 @@
       "link": true
     },
     "node_modules/@hatchifyjs/sequelize-create-with-associations": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/sequelize-create-with-associations/-/sequelize-create-with-associations-0.6.4.tgz",
-      "integrity": "sha512-RhO08o6k+n3OykHjWtqNt637li4wxt7kZSzC0pDUWRqH0Fw8T2fv1qUEwk+q+jnmbuZV2JKF/lK8vd3ZVcAECg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/sequelize-create-with-associations/-/sequelize-create-with-associations-0.6.5.tgz",
+      "integrity": "sha512-W21skqO01ypTtfEyxaLeta9SVWPzzaOqClq4r4cscTMsqSkp69FT+BYCoeCMqO7W9oO7VBwg82SItVwN4JAo+w==",
       "dependencies": {
         "inflection": "^2.0.1"
       },
@@ -3943,6 +3943,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/jsonapi-serializer": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonapi-serializer/-/jsonapi-serializer-3.6.6.tgz",
+      "integrity": "sha512-V9Hv5Q52h4Oz9fUsCTrYPk2QnlRSW4ECcGk7A9ooLp+RbDiNpogaDueLvvPBuBuETeE4tb+DG4TjUXNlxAa8/g==",
       "dev": true
     },
     "node_modules/@types/keygrip": {
@@ -17075,6 +17081,7 @@
         "@bitovi/eslint-config": "^1.6.0",
         "@koa/router": "^12.0.0",
         "@types/jest": "^29.2.1",
+        "@types/jsonapi-serializer": "^3.6.6",
         "@types/koa__router": "^12.0.0",
         "@types/node": "^18.11.9",
         "@types/supertest": "^2.0.12",
@@ -17101,9 +17108,9 @@
       "license": "MIT",
       "dependencies": {
         "@bitovi/querystring-parser": "^0.7.7",
-        "@bitovi/sequelize-querystring-parser": "^0.2.7",
+        "@bitovi/sequelize-querystring-parser": "^0.2.8",
         "@hatchifyjs/core": "^0.1.11",
-        "@hatchifyjs/sequelize-create-with-associations": "^0.6.4",
+        "@hatchifyjs/sequelize-create-with-associations": "^0.6.5",
         "co-body": "^6.1.0",
         "json-api-serializer": "^2.6.6",
         "lodash": "^4.17.21",
@@ -17825,20 +17832,20 @@
       "requires": {}
     },
     "@bitovi/querystring-parser": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.7.7.tgz",
-      "integrity": "sha512-bSY+r/z2gGV3HYeipPY2kQVhthUwjPAUiFInIf4pyQ955Be1QjU4qtjBDqVM5V5GD7gigOcFGrAeksndi+R9CQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@bitovi/querystring-parser/-/querystring-parser-0.7.8.tgz",
+      "integrity": "sha512-QLP18EA/yA3oGnFTXn6iRtVVmJ6yw/nySVRF9PV2+/1hOG7Ehds2Z55WNJliL65ge7HQytxf+gjc0ekVCUYMRQ==",
       "requires": {
         "qs": "^6.10.3",
         "sequelize": "^6.21.2"
       }
     },
     "@bitovi/sequelize-querystring-parser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@bitovi/sequelize-querystring-parser/-/sequelize-querystring-parser-0.2.7.tgz",
-      "integrity": "sha512-9zdZSWVNTEXjWHkuJo2EoFX0FTVqRVEZ2gewxyzNDR6On2yTgcHcb08YcnuCnz7cln5kgs5+HladvvamL9dSRQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@bitovi/sequelize-querystring-parser/-/sequelize-querystring-parser-0.2.8.tgz",
+      "integrity": "sha512-Iib10tJd0e7sah1qVk/yZCXfXFU66H/ruIIpT7f8U5ONCUt1LRuPxDJQytXzIQi36o9uC+YBArDXZVEpSK0B6w==",
       "requires": {
-        "@bitovi/querystring-parser": "^0.7.7",
+        "@bitovi/querystring-parser": "^0.7.8",
         "sequelize": "^6.21.2"
       }
     },
@@ -18298,6 +18305,7 @@
         "@hatchifyjs/node": "^1.0.0",
         "@koa/router": "^12.0.0",
         "@types/jest": "^29.2.1",
+        "@types/jsonapi-serializer": "^3.6.6",
         "@types/koa__router": "^12.0.0",
         "@types/node": "^18.11.9",
         "@types/supertest": "^2.0.12",
@@ -18322,9 +18330,9 @@
       "requires": {
         "@bitovi/eslint-config": "^1.6.0",
         "@bitovi/querystring-parser": "^0.7.7",
-        "@bitovi/sequelize-querystring-parser": "^0.2.7",
+        "@bitovi/sequelize-querystring-parser": "^0.2.8",
         "@hatchifyjs/core": "^0.1.11",
-        "@hatchifyjs/sequelize-create-with-associations": "^0.6.4",
+        "@hatchifyjs/sequelize-create-with-associations": "^0.6.5",
         "@types/co-body": "^6.1.0",
         "@types/jest": "^29.2.1",
         "@types/json-api-serializer": "^2.6.3",
@@ -18444,9 +18452,9 @@
       }
     },
     "@hatchifyjs/sequelize-create-with-associations": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/sequelize-create-with-associations/-/sequelize-create-with-associations-0.6.4.tgz",
-      "integrity": "sha512-RhO08o6k+n3OykHjWtqNt637li4wxt7kZSzC0pDUWRqH0Fw8T2fv1qUEwk+q+jnmbuZV2JKF/lK8vd3ZVcAECg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@hatchifyjs/sequelize-create-with-associations/-/sequelize-create-with-associations-0.6.5.tgz",
+      "integrity": "sha512-W21skqO01ypTtfEyxaLeta9SVWPzzaOqClq4r4cscTMsqSkp69FT+BYCoeCMqO7W9oO7VBwg82SItVwN4JAo+w==",
       "requires": {
         "inflection": "^2.0.1"
       }
@@ -20232,6 +20240,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "@types/jsonapi-serializer": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonapi-serializer/-/jsonapi-serializer-3.6.6.tgz",
+      "integrity": "sha512-V9Hv5Q52h4Oz9fUsCTrYPk2QnlRSW4ECcGk7A9ooLp+RbDiNpogaDueLvvPBuBuETeE4tb+DG4TjUXNlxAa8/g==",
       "dev": true
     },
     "@types/keygrip": {

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -40,6 +40,7 @@
     "@bitovi/eslint-config": "^1.6.0",
     "@koa/router": "^12.0.0",
     "@types/jest": "^29.2.1",
+    "@types/jsonapi-serializer": "^3.6.6",
     "@types/koa__router": "^12.0.0",
     "@types/node": "^18.11.9",
     "@types/supertest": "^2.0.12",

--- a/packages/koa/src/attributes.spec.ts
+++ b/packages/koa/src/attributes.spec.ts
@@ -138,8 +138,7 @@ describe("Attribute Tests", () => {
     expect(find1.status).toBe(200)
     expect(find1.deserialized).toHaveProperty("length")
     expect(find1.deserialized.length).toBe(3)
-
-    find1.deserialized.forEach((entry) => {
+    ;(find1.deserialized as any[]).forEach((entry) => {
       expect(entry).toHaveProperty("first_name")
       expect(entry).not.toHaveProperty("last_name")
     })
@@ -150,8 +149,7 @@ describe("Attribute Tests", () => {
     expect(find2.status).toBe(200)
     expect(find2.deserialized).toHaveProperty("length")
     expect(find2.deserialized.length).toBe(3)
-
-    find2.deserialized.forEach((entry) => {
+    ;(find2.deserialized as any[]).forEach((entry) => {
       expect(entry).toHaveProperty("last_name")
       expect(entry).not.toHaveProperty("first_name")
     })

--- a/packages/koa/src/database.spec.ts
+++ b/packages/koa/src/database.spec.ts
@@ -69,10 +69,12 @@ describe("Naming rules", () => {
 
     for (const table of database) {
       const { columns: expectedColumns, tableName } = table
-      const [dbResult] = await hatchify._sequelize.query(
+      const [dbResult] = await hatchify.orm.query(
         `SELECT name FROM pragma_table_info("${tableName}")`,
       )
-      const columns = dbResult.map((row) => row.name)
+      const columns = (dbResult as Array<{ name: string }>).map(
+        (row) => row.name,
+      )
 
       expect(columns).toEqual(expect.arrayContaining(expectedColumns))
     }

--- a/packages/koa/src/exports.ts
+++ b/packages/koa/src/exports.ts
@@ -11,7 +11,6 @@ export {
 
 export type {
   HatchifyError,
-  HatchifyModel,
   HatchifyOptions,
   BelongsToManyResult,
   BelongsToResult,

--- a/packages/koa/src/jsonapi.spec.ts
+++ b/packages/koa/src/jsonapi.spec.ts
@@ -15,7 +15,7 @@ describe("JSON:API Tests", () => {
     },
   }
 
-  function serialize(data) {
+  function serialize(data: any) {
     const serializer = new Serializer("Model", {
       keyForAttribute: "camelCase",
       attributes: Object.keys(data),

--- a/packages/koa/src/jsonapiNamespace.spec.ts
+++ b/packages/koa/src/jsonapiNamespace.spec.ts
@@ -24,7 +24,7 @@ describe("JSON:API Tests", () => {
     },
   }
 
-  function serialize(data) {
+  function serialize(data: any) {
     const serializer = new Serializer("TestSchema_Model", {
       keyForAttribute: "camelCase",
       attributes: Object.keys(data),

--- a/packages/koa/src/middleware/koa.ts
+++ b/packages/koa/src/middleware/koa.ts
@@ -1,4 +1,7 @@
-import type { MiddlewareRequest } from "@hatchifyjs/node"
+import type {
+  Hatchify as HatchifyNode,
+  MiddlewareRequest,
+} from "@hatchifyjs/node"
 import {
   errorResponseHandler,
   getMiddlewareFunctions,
@@ -6,8 +9,6 @@ import {
 } from "@hatchifyjs/node"
 import type Koa from "koa"
 import type { Middleware as KoaMiddleware } from "koa"
-
-import type { Hatchify } from "../koa"
 
 /**
  * Provides a set of exported functions, per Model, that
@@ -52,11 +53,13 @@ export interface MiddlewareFunctionsKoa {
 }
 
 export function buildMiddlewareForModel(
-  hatchify: Hatchify,
-  modelName: string,
+  hatchify: HatchifyNode,
+  modelName: string | symbol,
 ): MiddlewareFunctionsKoa {
-  return Object.entries(getMiddlewareFunctions(hatchify, modelName)).reduce(
-    (acc, [name, genericFunction]) => ({
+  return Object.entries(
+    getMiddlewareFunctions(hatchify, modelName as string),
+  ).reduce(
+    (acc, [name, genericFunction]): MiddlewareFunctionsKoa => ({
       ...acc,
       [name]: async (context: Koa.Context, next: Koa.Next) => {
         const request: MiddlewareRequest = {
@@ -87,7 +90,7 @@ export async function errorMiddleware(
   try {
     await next()
   } catch (ex) {
-    const { errors, status } = errorResponseHandler(ex)
+    const { errors, status } = errorResponseHandler(ex as Error)
 
     ctx.status = status
     ctx.body = { jsonapi: { version: "1.0" }, errors }

--- a/packages/koa/src/naming.spec.ts
+++ b/packages/koa/src/naming.spec.ts
@@ -994,10 +994,10 @@ describe("Naming rules", () => {
 
       for (const table of database) {
         const { columns: expectedColumns, tableName } = table
-        const [dbResult] = await hatchify._sequelize.query(
+        const [dbResult] = await hatchify.orm.query(
           `SELECT name FROM pragma_table_info("${tableName}")`,
         )
-        const columns = dbResult.map((row) => row.name)
+        const columns = (dbResult as Array<{name: string}>).map((row) => row.name)
 
         expect(columns).toEqual(expect.arrayContaining(expectedColumns))
       }

--- a/packages/koa/src/queryStringFilters.spec.ts
+++ b/packages/koa/src/queryStringFilters.spec.ts
@@ -11,7 +11,14 @@ import * as dotenv from "dotenv"
 
 import { dbDialects, startServerWith } from "./testing/utils"
 
-const [john, jane] = [
+type User = {
+  name: string
+  age: number
+  startDate: string
+  onSite: boolean
+  manager: boolean
+}
+const [john, jane]: User[] = [
   {
     name: "John",
     age: 25,
@@ -388,7 +395,7 @@ describe.each(dbDialects)("queryStringFilters", (dialect) => {
 
   afterAll(async () => {
     const { body } = await fetch(`/api/users/?`)
-    const userIds = body.data.map(({ id }) => id)
+    const userIds = body.data.map(({ id }: { id: string }) => id)
     await fetch(`/api/users/${userIds[0]}`, {
       method: "delete",
     })
@@ -399,12 +406,20 @@ describe.each(dbDialects)("queryStringFilters", (dialect) => {
     await teardown()
   })
 
-  const validator = async ({ expectedResult, queryParam }) => {
+  const validator = async ({
+    expectedResult,
+    queryParam,
+  }: {
+    expectedResult: User[]
+    queryParam: string
+  }) => {
     const { body } = await fetch(`/api/users/?${queryParam}`)
     if (body.errors) {
       throw body.errors
     }
-    const users = body.data.map(({ attributes }) => attributes)
+    const users = body.data.map(
+      ({ attributes }: { attributes: User }) => attributes,
+    )
     expect(users).toEqual(
       expectedResult.map((er) => ({
         ...er,

--- a/packages/koa/src/testing/utils.ts
+++ b/packages/koa/src/testing/utils.ts
@@ -1,4 +1,5 @@
 import http from "node:http"
+import type { Server } from "node:http"
 
 import type { PartialSchema } from "@hatchifyjs/node"
 import { HatchifyError, codes, statusCodes } from "@hatchifyjs/node"
@@ -12,6 +13,13 @@ import { Hatchify, errorHandlerMiddleware } from "../koa"
 
 type Method = "get" | "post" | "patch" | "delete"
 
+export type ParseResult = {
+  text?: string
+  status?: number
+  serialized: any
+  deserialized: any
+}
+
 export const dbDialects: Dialect[] = ["postgres", "sqlite"]
 
 export async function startServerWith(
@@ -23,7 +31,7 @@ export async function startServerWith(
     options?: { method?: Method; headers?: object; body?: object },
   ) => Promise<any>
   teardown: () => Promise<void>
-  hatchify?
+  hatchify: Hatchify
 }> {
   dotenv.config({
     path: ".env",
@@ -95,7 +103,7 @@ export function createServer(
   return http.createServer(app.callback())
 }
 
-async function parse(result) {
+async function parse(result: request.Response): Promise<ParseResult> {
   let serialized
   let deserialized
   let text
@@ -159,19 +167,32 @@ export async function getDatabaseColumns(
   tableName: string,
   schemaName = "public",
 ): Promise<DatabaseColumn[]> {
-  const dialect: Dialect = hatchify.orm.getDialect()
+  const dialect: Dialect = hatchify.orm.getDialect() as Dialect
   let columns: DatabaseColumn[] = []
 
   if (dialect === "sqlite") {
-    const [[result], constraints] = await Promise.all([
-      hatchify._sequelize.query(
+    type resultRow = {
+      name: string
+      notnull: number
+      pk: number
+      type: string
+      dflt_value: string
+    }
+    type constraintRow = {
+      from: string
+      table: string
+      to: string
+    }
+
+    const [[result], constraints] = (await Promise.all([
+      hatchify.orm.query(
         `SELECT name, "notnull", pk, type, dflt_value FROM pragma_table_info('${tableName}')`,
       ),
-      hatchify._sequelize.query(`PRAGMA foreign_key_list(${tableName})`),
-    ])
+      hatchify.orm.query(`PRAGMA foreign_key_list(${tableName})`),
+    ])) as unknown as [[resultRow[]], constraintRow[]]
 
-    columns = result.map((column) => {
-      const foreignKeys = constraints.reduce(
+    columns = result.map((column: resultRow) => {
+      const foreignKeys: ForeignKey[] = constraints.reduce<ForeignKey[]>(
         (acc, constraint) =>
           constraint.from === column.name
             ? [
@@ -179,10 +200,11 @@ export async function getDatabaseColumns(
                 {
                   tableName: constraint.table,
                   columnName: constraint.to,
+                  schemaName: "",
                 },
               ]
             : acc,
-        [],
+        [] as ForeignKey[],
       )
 
       return {
@@ -195,15 +217,28 @@ export async function getDatabaseColumns(
       }
     })
   } else if (dialect === "postgres") {
-    const [[result], [constraints]] = await Promise.all([
-      hatchify._sequelize.query(
+    type resultRow = {
+      column_name: string
+      is_nullable: string
+      data_type: string
+      column_default: string
+    }
+    type constraintRow = {
+      type: string
+      column: string
+      foreignSchema: string
+      foreignTable: string
+      foreignColumn: string
+    }
+    const [[result], [constraints]] = (await Promise.all([
+      hatchify.orm.query(
         `
         SELECT column_name, is_nullable, data_type, column_default
         FROM information_schema.columns
         WHERE table_schema = :schemaName AND table_name = :tableName`,
         { replacements: { schemaName, tableName } },
       ),
-      hatchify._sequelize.query(
+      hatchify.orm.query(
         `
         SELECT
           tc.constraint_type AS type,
@@ -220,9 +255,9 @@ export async function getDatabaseColumns(
         WHERE tc.table_schema = :schemaName AND tc.table_name = :tableName`,
         { replacements: { schemaName, tableName } },
       ),
-    ])
+    ])) as unknown as [[resultRow[]], [constraintRow[]]]
 
-    columns = result.map((column) => {
+    columns = result.map<DatabaseColumn>((column) => {
       const foreignKeys = constraints.reduce(
         (acc, constraint) =>
           constraint.column === column.column_name &&
@@ -236,7 +271,7 @@ export async function getDatabaseColumns(
                 },
               ]
             : acc,
-        [],
+        [] as ForeignKey[],
       )
 
       return {
@@ -268,7 +303,7 @@ export async function getDatabaseColumns(
 /**
  * @deprecated Please use `startServerWith` and `fetch` instead
  */
-export async function GET(server, path) {
+export async function GET(server: Server, path: string): Promise<ParseResult> {
   const result = await request(server).get(path).set("authorization", "test")
   return parse(result)
 }
@@ -276,7 +311,10 @@ export async function GET(server, path) {
 /**
  * @deprecated Please use `startServerWith` and `fetch` instead
  */
-export async function DELETE(server, path) {
+export async function DELETE(
+  server: Server,
+  path: string,
+): Promise<ParseResult> {
   const result = await request(server).delete(path).set("authorization", "test")
 
   return await parse(result)
@@ -285,7 +323,12 @@ export async function DELETE(server, path) {
 /**
  * @deprecated Please use `startServerWith` and `fetch` instead
  */
-export async function POST(server, path, payload, type = "application/json") {
+export async function POST(
+  server: Server,
+  path: string,
+  payload: any,
+  type = "application/json",
+): Promise<ParseResult> {
   const result = await request(server)
     .post(path)
     .set("authorization", "test")
@@ -298,7 +341,12 @@ export async function POST(server, path, payload, type = "application/json") {
 /**
  * @deprecated Please use `startServerWith` and `fetch` instead
  */
-export async function PATCH(server, path, payload, type = "application/json") {
+export async function PATCH(
+  server: Server,
+  path: string,
+  payload: any,
+  type = "application/json",
+): Promise<ParseResult> {
   const result = await request(server)
     .patch(path)
     .set("authorization", "test")
@@ -311,7 +359,12 @@ export async function PATCH(server, path, payload, type = "application/json") {
 /**
  * @deprecated Please use `startServerWith` and `fetch` instead
  */
-export async function PUT(server, path, payload, type = "application/json") {
+export async function PUT(
+  server: Server,
+  path: string,
+  payload: any,
+  type = "application/json",
+): Promise<ParseResult> {
   const result = await request(server)
     .put(path)
     .set("authorization", "test")

--- a/packages/koa/tsconfig.json
+++ b/packages/koa/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "outDir": "dist",
     "sourceMap": true,
-    "strict": false,
-    "strictNullChecks": true
+    "strict": true,
+    "strictNullChecks": true,
+    "resolvePackageJsonImports": true
   }
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -31,7 +31,7 @@
     "@bitovi/querystring-parser": "^0.7.7",
     "@bitovi/sequelize-querystring-parser": "^0.2.7",
     "@hatchifyjs/core": "^0.1.11",
-    "@hatchifyjs/sequelize-create-with-associations": "^0.6.4",
+    "@hatchifyjs/sequelize-create-with-associations": "^0.6.5",
     "co-body": "^6.1.0",
     "json-api-serializer": "^2.6.6",
     "lodash": "^4.17.21",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/bitovi/hatchify#readme",
   "dependencies": {
     "@bitovi/querystring-parser": "^0.7.7",
-    "@bitovi/sequelize-querystring-parser": "^0.2.7",
+    "@bitovi/sequelize-querystring-parser": "^0.2.8",
     "@hatchifyjs/core": "^0.1.11",
     "@hatchifyjs/sequelize-create-with-associations": "^0.6.5",
     "co-body": "^6.1.0",

--- a/packages/node/src/everything/index.ts
+++ b/packages/node/src/everything/index.ts
@@ -14,7 +14,7 @@ export interface EverythingFunctions {
     querystring: string,
     id?: Identifier,
   ) => Promise<JSONAPIDocument>
-  destroy: (querystring: string, id?: Identifier) => Promise<JSONAPIDocument>
+  destroy: (querystring: string, id: Identifier) => Promise<JSONAPIDocument>
 }
 
 export function buildEverythingForModel(

--- a/packages/node/src/exports.ts
+++ b/packages/node/src/exports.ts
@@ -5,7 +5,6 @@ export type {
   BelongsToResult,
   HasManyResult,
   HasOneResult,
-  HatchifyModel,
   HatchifyOptions,
   MiddlewareRequest,
   MiddlewareResponse,

--- a/packages/node/src/internals.spec.ts
+++ b/packages/node/src/internals.spec.ts
@@ -14,7 +14,7 @@ describe("Internal Tests", () => {
     },
   }
 
-  let hatchify
+  let hatchify: Hatchify
   afterEach(async () => {
     await hatchify.orm.close()
   })

--- a/packages/node/src/middleware/node.ts
+++ b/packages/node/src/middleware/node.ts
@@ -149,6 +149,7 @@ export function updateMiddleware(hatchify: Hatchify, modelName: string) {
 
 export function destroyMiddleware(hatchify: Hatchify, modelName: string) {
   return async function destroyImpl({
+    errorCallback,
     path,
     querystring,
   }: MiddlewareRequest): Promise<MiddlewareResponse> {
@@ -158,6 +159,10 @@ export function destroyMiddleware(hatchify: Hatchify, modelName: string) {
     }
 
     const params = hatchify.getHatchifyURLParamsForRoute(path)
+
+    if (!params.id) {
+      throw errorCallback(400, "BAD_REQUEST")
+    }
 
     return {
       body: await hatchify.everything[modelName].destroy(
@@ -257,7 +262,7 @@ export function handleAllMiddleware(hatchify: Hatchify) {
         }
       }
     } catch (error) {
-      const { errors, status } = errorResponseHandler(error)
+      const { errors, status } = errorResponseHandler(error as Error)
 
       return {
         status,
@@ -267,7 +272,7 @@ export function handleAllMiddleware(hatchify: Hatchify) {
   }
 }
 
-function resolveWildcard(hatchify: Hatchify, path): string {
+function resolveWildcard(hatchify: Hatchify, path: string): string {
   const params = hatchify.getHatchifyURLParamsForRoute(path)
   if (!params.model) {
     throw [

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,5 +1,5 @@
-import type { PartialSchema } from "@hatchifyjs/core"
-import type { IAssociation } from "@hatchifyjs/sequelize-create-with-associations"
+import type { FinalSchema, PartialSchema } from "@hatchifyjs/core"
+import type { IAssociation } from "@hatchifyjs/sequelize-create-with-associations/dist/sequelize/types"
 import JSONAPISerializer from "json-api-serializer"
 import { snakeCase } from "lodash"
 import { match } from "path-to-regexp"
@@ -22,11 +22,10 @@ import { buildSerializerForModel } from "./serialize"
 import type { SerializeFunctions } from "./serialize"
 import type {
   FunctionsHandler,
-  HatchifyModel,
-  HatchifyModelCollection,
   HatchifyOptions,
   ModelFunctionsCollection,
   SequelizeModelsCollection,
+  SequelizeWithHatchify,
   Virtuals,
 } from "./types"
 import { pluralize } from "./utils/pluralize"
@@ -45,7 +44,7 @@ import { pluralize } from "./utils/pluralize"
  */
 export class Hatchify {
   private _sequelizeModels: SequelizeModelsCollection
-  private _sequelize: Sequelize
+  private _sequelize: SequelizeWithHatchify
   private _serializer = new JSONAPISerializer()
   private _allowedMethods = ["GET", "POST", "PATCH", "DELETE"]
   private _pluralToSingularModelNames: { [plural: string]: string }
@@ -76,7 +75,7 @@ export class Hatchify {
       this._sequelize.connectionManager.getConnection = async function (
         ...args: Parameters<typeof gc>
       ) {
-        const db: Database = await gc.apply(this, args)
+        const db: Database = (await gc.apply(this, args)) as Database
 
         await new Promise((resolve) =>
           db.run("PRAGMA case_sensitive_like=ON", resolve),
@@ -86,14 +85,14 @@ export class Hatchify {
     }
     this._serializer = new JSONAPISerializer()
 
-    const { associationsLookup, sequelizeModels } = convertHatchifyModels(
+    const { associationsLookup, models } = convertHatchifyModels(
       this._sequelize,
       this._serializer,
       schemas,
     )
 
     this.associationsLookup = associationsLookup
-    this._sequelizeModels = sequelizeModels
+    this._sequelizeModels = models
 
     this._pluralToSingularModelNames = Object.keys(
       this._sequelizeModels,
@@ -145,7 +144,7 @@ export class Hatchify {
    * Returns an object mapping model names to Hatchify models
    * @hidden
    */
-  get models(): HatchifyModelCollection {
+  get models(): SequelizeModelsCollection {
     return buildHatchifyModelObject(this._sequelizeModels)
   }
 
@@ -205,11 +204,11 @@ export class Hatchify {
    * For more information about the underlying per-model functions:
    * @see {@link HatchifyModel}
    *
-   * @returns {ModelFunctionsCollection<HatchifyModel>}
+   * @returns {ModelFunctionsCollection<FinalSchema>}
    * @category General Use
    */
-  get schema() {
-    return buildExportWrapper<HatchifyModel>(this, buildSchemaForModel)
+  get schema(): ModelFunctionsCollection<FinalSchema> {
+    return buildExportWrapper<FinalSchema>(this, buildSchemaForModel)
   }
 
   /**
@@ -437,7 +436,7 @@ export class Hatchify {
         {},
       )) as unknown as string[]
 
-      const uniqueNamespaces = Object.values(this.models).reduce(
+      const uniqueNamespaces = Object.values(this.schema).reduce(
         (acc, model) =>
           model?.namespace && !existingNamespaces.includes(model.namespace)
             ? acc.add(model.namespace)
@@ -471,7 +470,7 @@ export function buildExportWrapper<T>(
     "*": handlerFunction(hatchify, "*"),
     allModels: handlerFunction(hatchify, "*"),
   }
-  Object.keys(hatchify.models).forEach((modelName) => {
+  Object.keys(hatchify.models).forEach((modelName: string) => {
     wrapper[modelName] = handlerFunction(hatchify, modelName)
   })
 

--- a/packages/node/src/parse/builder.spec.ts
+++ b/packages/node/src/parse/builder.spec.ts
@@ -12,7 +12,7 @@ import { UnexpectedValueError } from "../error"
 import { Hatchify } from "../node"
 
 describe("builder", () => {
-  const User: PartialSchema = {
+  const UserSchema: PartialSchema = {
     name: "User",
     attributes: {
       name: string(),
@@ -22,7 +22,7 @@ describe("builder", () => {
       todos: hasMany(),
     },
   }
-  const Todo: PartialSchema = {
+  const TodoSchema: PartialSchema = {
     name: "Todo",
     attributes: {
       name: string(),
@@ -33,7 +33,15 @@ describe("builder", () => {
       user: belongsTo(),
     },
   }
-  const hatchify = new Hatchify({ User, Todo }, { prefix: "/api" })
+  const hatchify = new Hatchify(
+    {
+      User: UserSchema,
+      Todo: TodoSchema,
+    },
+    { prefix: "/api" },
+  )
+
+  const { User, Todo } = hatchify.schema
 
   describe("buildFindOptions", () => {
     it("works with ID attribute provided", () => {
@@ -189,7 +197,7 @@ describe("builder", () => {
         buildFindOptions(hatchify, Todo, "fields[todo]=invalid"),
       ).rejects.toEqualErrors([
         new UnexpectedValueError({
-          detail: `URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance'.`,
+          detail: `URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'userId'.`,
           parameter: `fields[todo]`,
         }),
       ])
@@ -200,7 +208,7 @@ describe("builder", () => {
         buildFindOptions(hatchify, Todo, "filter[namee][]=test"),
       ).rejects.toEqualErrors([
         new UnexpectedValueError({
-          detail: `URL must have 'filter[x]' where 'x' is one of 'name', 'dueDate', 'importance'.`,
+          detail: `URL must have 'filter[x]' where 'x' is one of 'name', 'dueDate', 'importance', 'userId'.`,
           parameter: "filter[namee]",
         }),
       ])
@@ -222,7 +230,7 @@ describe("builder", () => {
         buildFindOptions(hatchify, Todo, "sort=invalid"),
       ).rejects.toEqualErrors([
         new UnexpectedValueError({
-          detail: `URL must have 'sort' as comma separated values containing one or more of 'name', 'dueDate', 'importance'.`,
+          detail: `URL must have 'sort' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'userId'.`,
           parameter: `sort`,
         }),
       ])

--- a/packages/node/src/parse/builder.spec.ts
+++ b/packages/node/src/parse/builder.spec.ts
@@ -33,15 +33,23 @@ describe("builder", () => {
       user: belongsTo(),
     },
   }
+  const DisconnectedSchemaSchema: PartialSchema = {
+    name: "DisconnectedSchema",
+    attributes: {
+      name: string(),
+      importance: integer(),
+    },
+  }
   const hatchify = new Hatchify(
     {
       User: UserSchema,
       Todo: TodoSchema,
+      DisconnectedSchema: DisconnectedSchemaSchema,
     },
     { prefix: "/api" },
   )
 
-  const { User, Todo } = hatchify.schema
+  const { User, Todo, DisconnectedSchema } = hatchify.schema
 
   describe("buildFindOptions", () => {
     it("works with ID attribute provided", () => {
@@ -231,6 +239,30 @@ describe("builder", () => {
       ).rejects.toEqualErrors([
         new UnexpectedValueError({
           detail: `URL must have 'sort' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'userId'.`,
+          parameter: `sort`,
+        }),
+      ])
+    })
+
+    it("handles unknown sort assocations", async () => {
+      await expect(async () =>
+        buildFindOptions(hatchify, Todo, "sort=invalid.alsoinvalid"),
+      ).rejects.toEqualErrors([
+        new UnexpectedValueError({
+          detail: `URL must have 'sort' as comma separated values containing one or more attributes of 'user'.`,
+          parameter: `sort`,
+        }),
+      ])
+
+      await expect(async () =>
+        buildFindOptions(
+          hatchify,
+          DisconnectedSchema,
+          "sort=invalid.alsoinvalid",
+        ),
+      ).rejects.toEqualErrors([
+        new UnexpectedValueError({
+          detail: `URL must have 'sort' as comma separated values containing one or more attributes of DisconnectedSchema.`,
           parameter: `sort`,
         }),
       ])

--- a/packages/node/src/parse/builder.ts
+++ b/packages/node/src/parse/builder.ts
@@ -1,5 +1,6 @@
-import type QuerystringParsingError from "@bitovi/querystring-parser/lib/errors/querystring-parsing-error"
+// @ts-ignore TS7016
 import querystringParser from "@bitovi/sequelize-querystring-parser"
+import type { FinalSchema } from "@hatchifyjs/core"
 import { noCase } from "no-case"
 import type {
   CreateOptions,
@@ -7,6 +8,7 @@ import type {
   Dialect,
   FindOptions,
   Identifier,
+  ProjectionAlias,
   UpdateOptions,
 } from "sequelize"
 
@@ -15,26 +17,38 @@ import { handleSqliteLike } from "./handleSqliteLike"
 import { handleWhere } from "./handleWhere"
 import { UnexpectedValueError } from "../error"
 import type { Hatchify } from "../node"
-import type { HatchifyModel } from "../types"
 
-export interface QueryStringParser<T> {
+export interface QueryStringParser<T, E = UnexpectedValueError> {
   data: T
-  errors: Error[]
+  errors: E[]
   orm: "sequelize"
+}
+
+export interface SequelizeQueryStringParserLib {
+  parse: <T>(query: string) => QueryStringParser<T, QueryStringParsingError>
+}
+
+export interface QueryStringParsingError extends Error {
+  querystring: string
+  paramKey: string
+  paramValue: any
+  name: "QuerystringParsingError"
 }
 
 export function buildFindOptions(
   hatchify: Hatchify,
-  model: HatchifyModel,
+  model: FinalSchema,
   querystring: string,
   id?: Identifier,
 ): QueryStringParser<FindOptions> {
   const dialect = hatchify.orm.getDialect() as Dialect
-  let ops: QueryStringParser<FindOptions> = querystringParser.parse(querystring)
+  const qspOps: QueryStringParser<FindOptions, QueryStringParsingError> = (
+    querystringParser as SequelizeQueryStringParserLib
+  ).parse<FindOptions>(querystring)
 
-  if (ops.errors.length) {
-    throw ops.errors.map(
-      (error: QuerystringParsingError) =>
+  if (qspOps.errors.length) {
+    throw qspOps.errors.map(
+      (error: QueryStringParsingError) =>
         new UnexpectedValueError({
           parameter: error.paramKey,
           detail: error.message,
@@ -42,11 +56,11 @@ export function buildFindOptions(
     )
   }
 
-  if (!ops.data) {
-    return ops
+  if (!qspOps.data) {
+    return qspOps as unknown as QueryStringParser<FindOptions>
   }
 
-  ops = handleWhere(ops, model)
+  let ops: QueryStringParser<FindOptions> = handleWhere(qspOps, model)
 
   if (dialect === "sqlite") {
     ops = handleSqliteDateNestedColumns(ops, dialect)
@@ -63,8 +77,9 @@ export function buildFindOptions(
       .map((x) => noCase(x as string, { delimiter: "-" }))
       .join("-")
 
-    ops.data.attributes.forEach((attribute: string) => {
-      if (attribute !== "id" && !model.attributes[attribute]) {
+    ops.data.attributes.forEach((attribute: string | ProjectionAlias) => {
+      const stringAttribute: string = attribute as unknown as string // no other types come out of the parser
+      if (stringAttribute !== "id" && !model.attributes[stringAttribute]) {
         ops.errors.push(
           new UnexpectedValueError({
             detail: `URL must have 'fields[${modelName}]' as comma separated values containing one or more of ${Object.keys(
@@ -80,7 +95,7 @@ export function buildFindOptions(
   }
 
   if (Array.isArray(ops.data.order)) {
-    for (const orderItem of ops.data.order) {
+    for (const orderItem of ops.data.order as string[][]) {
       const attribute = orderItem[0]
 
       if (attribute !== "id" && !model.attributes[attribute]) {
@@ -122,12 +137,12 @@ export function buildUpdateOptions(
   querystring: string,
   id?: Identifier,
 ): QueryStringParser<UpdateOptions> {
-  const ops: QueryStringParser<UpdateOptions> =
+  const ops: QueryStringParser<UpdateOptions, QueryStringParsingError> =
     querystringParser.parse(querystring)
 
   if (ops.errors.length) {
     throw ops.errors.map(
-      (error: QuerystringParsingError) =>
+      (error: QueryStringParsingError) =>
         new UnexpectedValueError({
           parameter: error.paramKey,
           detail: error.message,
@@ -142,19 +157,19 @@ export function buildUpdateOptions(
     }
   }
 
-  return ops
+  return ops as unknown as QueryStringParser<UpdateOptions>
 }
 
 export function buildDestroyOptions(
   querystring: string,
   id?: Identifier,
 ): QueryStringParser<DestroyOptions> {
-  const ops: QueryStringParser<DestroyOptions> =
+  const ops: QueryStringParser<DestroyOptions, QueryStringParsingError> =
     querystringParser.parse(querystring)
 
   if (ops.errors.length) {
     throw ops.errors.map(
-      (error: QuerystringParsingError) =>
+      (error: QueryStringParsingError) =>
         new UnexpectedValueError({
           parameter: error.paramKey,
           detail: error.message,
@@ -170,5 +185,5 @@ export function buildDestroyOptions(
   }
 
   // Perform additional checks if needed...
-  return ops
+  return ops as unknown as QueryStringParser<DestroyOptions>
 }

--- a/packages/node/src/parse/handleWhere.ts
+++ b/packages/node/src/parse/handleWhere.ts
@@ -1,10 +1,10 @@
+import type { FinalSchema } from "@hatchifyjs/core"
 import type { FindOptions } from "sequelize"
 
-import type { QueryStringParser } from "./builder"
+import type { QueryStringParser, QueryStringParsingError } from "./builder"
 import { getColumnName } from "./getColumnName"
 import { walk } from "./walk"
 import { UnexpectedValueError } from "../error"
-import type { HatchifyModel } from "../types"
 import { getFullModelName } from "../utils/getFullModelName"
 
 interface Include {
@@ -12,10 +12,10 @@ interface Include {
 }
 
 export function handleWhere(
-  ops: QueryStringParser<FindOptions>,
-  model: HatchifyModel,
-): QueryStringParser<FindOptions> {
-  const errors: Error[] = []
+  ops: QueryStringParser<FindOptions, QueryStringParsingError>,
+  model: FinalSchema,
+): QueryStringParser<FindOptions, UnexpectedValueError> {
+  const errors: UnexpectedValueError[] = []
 
   const where = walk(ops.data.where, (key, value) => {
     if (typeof key !== "string") {
@@ -65,6 +65,6 @@ export function handleWhere(
       ...ops.data,
       where,
     },
-    errors: [...ops.errors, ...errors],
+    errors: [...(ops.errors as unknown as UnexpectedValueError[]), ...errors],
   }
 }

--- a/packages/node/src/parse/index.spec.ts
+++ b/packages/node/src/parse/index.spec.ts
@@ -45,7 +45,7 @@ describe("index", () => {
 
   describe("buildParserForModelStandalone", () => {
     const { findAll, findOne, findAndCountAll, create, update, destroy } =
-      buildParserForModelStandalone(hatchedNode, Todo)
+      buildParserForModelStandalone(hatchedNode, hatchedNode.schema.Todo)
 
     describe("findAll", () => {
       it("works with ID attribute provided", async () => {
@@ -83,7 +83,7 @@ describe("index", () => {
         await expect(findAll("fields[todo]=invalid")).rejects.toEqualErrors([
           new UnexpectedValueError({
             detail:
-              "URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status'.",
+              "URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status', 'userId'.",
             parameter: "fields[todo]",
           }),
         ])
@@ -146,7 +146,7 @@ describe("index", () => {
         ).rejects.toEqualErrors([
           new UnexpectedValueError({
             detail:
-              "URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status'.",
+              "URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status', 'userId'.",
             parameter: "fields[todo]",
           }),
         ])
@@ -212,7 +212,7 @@ describe("index", () => {
         await expect(findOne("fields[todo]=invalid", 1)).rejects.toEqualErrors([
           new UnexpectedValueError({
             detail:
-              "URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status'.",
+              "URL must have 'fields[todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status', 'userId'.",
             parameter: "fields[todo]",
           }),
         ])
@@ -372,7 +372,10 @@ describe("index", () => {
     }
 
     const hatchedNode = new Hatchify({ Todo })
-    const { findAll } = buildParserForModelStandalone(hatchedNode, Todo)
+    const { findAll } = buildParserForModelStandalone(
+      hatchedNode,
+      hatchedNode.schema.Todo,
+    )
 
     it("handles invalid include", async () => {
       await expect(findAll("include=user")).rejects.toEqualErrors([

--- a/packages/node/src/parse/index.ts
+++ b/packages/node/src/parse/index.ts
@@ -1,3 +1,4 @@
+import type { FinalSchema } from "@hatchifyjs/core"
 import type {
   CreateOptions,
   DestroyOptions,
@@ -9,7 +10,7 @@ import type {
 import { buildDestroyOptions, buildFindOptions } from "./builder"
 import { validateFindOptions, validateStructure } from "./validator"
 import type { Hatchify } from "../node"
-import type { HatchifyModel, JSONObject } from "../types"
+import type { JSONObject } from "../types"
 import { getFullModelName } from "../utils/getFullModelName"
 
 /**
@@ -39,7 +40,7 @@ export interface ParseFunctions {
 
 async function findAllImpl(
   hatchify: Hatchify,
-  model: HatchifyModel,
+  model: FinalSchema,
   querystring: string,
 ) {
   const { data, errors } = buildFindOptions(hatchify, model, querystring)
@@ -52,9 +53,9 @@ async function findAllImpl(
 
 async function findOneImpl(
   hatchify: Hatchify,
-  model: HatchifyModel,
+  model: FinalSchema,
   querystring: string,
-  id,
+  id: Identifier,
 ) {
   const { data, errors } = buildFindOptions(hatchify, model, querystring, id)
   if (errors.length) {
@@ -66,7 +67,7 @@ async function findOneImpl(
 
 async function findAndCountAllImpl(
   hatchify: Hatchify,
-  model: HatchifyModel,
+  model: FinalSchema,
   querystring: string,
 ) {
   const { data, errors } = buildFindOptions(hatchify, model, querystring)
@@ -77,7 +78,7 @@ async function findAndCountAllImpl(
   return data
 }
 
-async function createImpl<T extends HatchifyModel = HatchifyModel>(
+async function createImpl<T extends FinalSchema = FinalSchema>(
   hatchify: Hatchify,
   model: T,
   body: any,
@@ -96,9 +97,9 @@ async function createImpl<T extends HatchifyModel = HatchifyModel>(
 
 async function updateImpl(
   hatchify: Hatchify,
-  model: HatchifyModel,
+  model: FinalSchema,
   body: any,
-  id,
+  id?: Identifier,
 ) {
   validateStructure(body, model, hatchify)
   const parsedBody = await hatchify.serializer.deserialize(
@@ -122,7 +123,7 @@ async function destroyImpl(querystring: string, id?: Identifier) {
 
 export function buildParserForModelStandalone(
   hatchify: Hatchify,
-  model: HatchifyModel,
+  model: FinalSchema,
 ): ParseFunctions {
   return {
     findAll: async (querystring) => findAllImpl(hatchify, model, querystring),
@@ -140,5 +141,5 @@ export function buildParserForModel(
   hatchify: Hatchify,
   modelName: string,
 ): ParseFunctions {
-  return buildParserForModelStandalone(hatchify, hatchify.models[modelName])
+  return buildParserForModelStandalone(hatchify, hatchify.schema[modelName])
 }

--- a/packages/node/src/parse/indexNamespace.spec.ts
+++ b/packages/node/src/parse/indexNamespace.spec.ts
@@ -18,7 +18,7 @@ const RelationshipPathDetail =
   "URL must have 'include' as one or more of 'lipitorUser', 'xanaxUser'."
 
 describe("indexNamespace", () => {
-  const Lipitor_User: PartialSchema = {
+  const Lipitor_User_Schema: PartialSchema = {
     name: "User",
     namespace: "Lipitor",
     attributes: {
@@ -28,7 +28,7 @@ describe("indexNamespace", () => {
       lipitorTodos: hasMany("Pfizer_Todo"),
     },
   }
-  const Xanax_User: PartialSchema = {
+  const Xanax_User_Schema: PartialSchema = {
     name: "User",
     namespace: "Xanax",
     attributes: {
@@ -39,7 +39,7 @@ describe("indexNamespace", () => {
     },
   }
 
-  const Pfizer_Todo: PartialSchema = {
+  const Pfizer_Todo_Schema: PartialSchema = {
     name: "Todo",
     namespace: "Pfizer",
     attributes: {
@@ -54,7 +54,13 @@ describe("indexNamespace", () => {
     },
   }
 
-  const hatchedNode = new Hatchify({ Pfizer_Todo, Lipitor_User, Xanax_User })
+  const hatchedNode = new Hatchify({
+    Pfizer_Todo: Pfizer_Todo_Schema,
+    Lipitor_User: Lipitor_User_Schema,
+    Xanax_User: Xanax_User_Schema,
+  })
+
+  const { Pfizer_Todo } = hatchedNode.schema
 
   describe("buildParserForModelStandalone", () => {
     const { findAll, findOne, findAndCountAll, create, update, destroy } =
@@ -98,7 +104,7 @@ describe("indexNamespace", () => {
         ).rejects.toEqualErrors([
           new UnexpectedValueError({
             detail:
-              "URL must have 'fields[pfizer-todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status'.",
+              "URL must have 'fields[pfizer-todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status', 'lipitorUserId', 'xanaxUserId', 'lipitor_UserId', 'xanax_UserId'.",
             parameter: "fields[pfizer-todo]",
           }),
         ])
@@ -161,7 +167,7 @@ describe("indexNamespace", () => {
         ).rejects.toEqualErrors([
           new UnexpectedValueError({
             detail:
-              "URL must have 'fields[pfizer-todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status'.",
+              "URL must have 'fields[pfizer-todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status', 'lipitorUserId', 'xanaxUserId', 'lipitor_UserId', 'xanax_UserId'.",
             parameter: "fields[pfizer-todo]",
           }),
         ])
@@ -229,7 +235,7 @@ describe("indexNamespace", () => {
         ).rejects.toEqualErrors([
           new UnexpectedValueError({
             detail:
-              "URL must have 'fields[pfizer-todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status'.",
+              "URL must have 'fields[pfizer-todo]' as comma separated values containing one or more of 'name', 'dueDate', 'importance', 'status', 'lipitorUserId', 'xanaxUserId', 'lipitor_UserId', 'xanax_UserId'.",
             parameter: "fields[pfizer-todo]",
           }),
         ])
@@ -389,7 +395,10 @@ describe("indexNamespace", () => {
     }
 
     const hatchedNode = new Hatchify({ Todo })
-    const { findAll } = buildParserForModelStandalone(hatchedNode, Todo)
+    const { findAll } = buildParserForModelStandalone(
+      hatchedNode,
+      hatchedNode.schema.Todo,
+    )
 
     it("handles invalid include", async () => {
       await expect(findAll("include=user")).rejects.toEqualErrors([

--- a/packages/node/src/parse/walk.ts
+++ b/packages/node/src/parse/walk.ts
@@ -9,7 +9,10 @@ export const walk: <T>(
       ...Object.getOwnPropertyNames(maybeObj),
       ...Object.getOwnPropertySymbols(maybeObj),
     ]
-    const entries = keys.map((k) => [k, maybeObj[k]])
+    const entries = keys.map((k) => [
+      k,
+      (maybeObj as { [key: typeof k]: any })[k],
+    ])
     return entries.reduce((acc, [key, value]) => {
       const [newVal, newKey = key] =
         (fn(key, value) as unknown as [unknown, string | symbol]) ?? []

--- a/packages/node/src/schema/index.ts
+++ b/packages/node/src/schema/index.ts
@@ -1,9 +1,11 @@
+import type { FinalSchema } from "@hatchifyjs/core"
+
 import type { Hatchify } from "../node"
-import type { HatchifyModel } from "../types"
+import { HatchifySymbolModel } from "../types"
 
 export function buildSchemaForModel(
   hatchify: Hatchify,
   modelName: string,
-): HatchifyModel {
-  return hatchify.models[modelName]
+): FinalSchema {
+  return hatchify.models[modelName]?.[HatchifySymbolModel]
 }

--- a/packages/node/src/sequelize/buildHatchifyModelObject.ts
+++ b/packages/node/src/sequelize/buildHatchifyModelObject.ts
@@ -1,14 +1,9 @@
-import { HatchifySymbolModel } from "../types"
-import type {
-  HatchifyModelCollection,
-  SequelizeModelsCollection,
-} from "../types"
+import type { SequelizeModelsCollection } from "../types"
 
 export function buildHatchifyModelObject(
   models: SequelizeModelsCollection,
-): HatchifyModelCollection {
-  return Object.entries(models).reduce(
-    (acc, [name, model]) => ({ ...acc, [name]: model[HatchifySymbolModel] }),
-    {},
-  )
+): SequelizeModelsCollection {
+  return {
+    ...models,
+  }
 }

--- a/packages/node/src/sequelize/convertHatchifyModels.spec.ts
+++ b/packages/node/src/sequelize/convertHatchifyModels.spec.ts
@@ -21,7 +21,7 @@ describe("convertHatchifyModels", () => {
 
     expect(models).toEqual({
       associationsLookup: { User: {} },
-      sequelizeModels: {
+      models: {
         User: expect.any(Function),
       },
     })

--- a/packages/node/src/sequelize/createSequelizeInstance.ts
+++ b/packages/node/src/sequelize/createSequelizeInstance.ts
@@ -2,14 +2,16 @@ import { extendSequelize } from "@hatchifyjs/sequelize-create-with-associations"
 import { Sequelize } from "sequelize"
 import type { Options } from "sequelize"
 
+import type { SequelizeWithHatchify } from "../types"
+
 export function createSequelizeInstance(
   options: Options = {
     dialect: "sqlite",
     storage: ":memory:",
     logging: false,
   },
-): Sequelize {
+): SequelizeWithHatchify {
   extendSequelize(Sequelize)
 
-  return new Sequelize(options)
+  return new Sequelize(options) as SequelizeWithHatchify
 }

--- a/packages/node/src/serialize/index.ts
+++ b/packages/node/src/serialize/index.ts
@@ -1,10 +1,10 @@
-import type { IAssociation } from "@hatchifyjs/sequelize-create-with-associations"
+import type { FinalSchema } from "@hatchifyjs/core"
+import type { IAssociation } from "@hatchifyjs/sequelize-create-with-associations/dist/sequelize/types"
 import type JSONAPISerializer from "json-api-serializer"
 import type { JSONAPIDocument } from "json-api-serializer"
 import type { Model } from "sequelize"
 
 import type { Hatchify } from "../node"
-import type { HatchifyModel } from "../types"
 import { getFullModelName } from "../utils/getFullModelName"
 
 /**
@@ -25,14 +25,14 @@ export interface SerializeFunctions<
    *
    * @returns {JSONAPIDocument}
    */
-  findAll: (data: T[], attributes) => Promise<JSONAPIDocument>
-  findOne: (data: T, attributes) => Promise<JSONAPIDocument>
+  findAll: (data: T[], attributes: any) => Promise<JSONAPIDocument>
+  findOne: (data: T, attributes: any) => Promise<JSONAPIDocument>
   findAndCountAll: (
     data: {
       rows: T[]
       count: number
     },
-    attributes,
+    attributes: any,
   ) => Promise<JSONAPIDocument>
   create: (data: T) => Promise<JSONAPIDocument>
   update: (rowCount: number) => Promise<JSONAPIDocument>
@@ -42,8 +42,8 @@ export interface SerializeFunctions<
 async function findAllImpl(
   hatchify: Hatchify,
   name: string,
-  array,
-  attributes,
+  array: any[],
+  attributes: any,
 ) {
   if (hatchify.virtuals[name]) {
     return serializeWithoutUnsolicitedVirtuals(
@@ -61,8 +61,8 @@ async function findAllImpl(
 async function findOneImpl(
   hatchify: Hatchify,
   name: string,
-  instance,
-  attributes,
+  instance: any,
+  attributes: any,
 ) {
   if (hatchify.virtuals[name]) {
     return serializeWithoutUnsolicitedVirtuals(
@@ -79,8 +79,8 @@ async function findOneImpl(
 async function findAndCountAllImpl(
   hatchify: Hatchify,
   name: string,
-  result,
-  attributes,
+  result: any,
+  attributes: any,
 ) {
   if (hatchify.virtuals[name]) {
     return serializeWithoutUnsolicitedVirtuals(
@@ -97,15 +97,15 @@ async function findAndCountAllImpl(
   })
 }
 
-async function createImpl(hatchify: Hatchify, name: string, instance) {
+async function createImpl(hatchify: Hatchify, name: string, instance: any) {
   return hatchify.serializer.serialize(name, instance)
 }
 
-async function destroyImpl(hatchify: Hatchify, name: string, rowCount) {
+async function destroyImpl(hatchify: Hatchify, name: string, rowCount: any) {
   return hatchify.serializer.serialize(name, null, { count: rowCount })
 }
 
-async function updateImpl(hatchify: Hatchify, name: string, rowCount) {
+async function updateImpl(hatchify: Hatchify, name: string, rowCount: any) {
   return hatchify.serializer.serialize(name, null, { count: rowCount })
 }
 
@@ -128,7 +128,7 @@ export function buildSerializerForModel(
 
 export function registerSchema(
   serializer: JSONAPISerializer,
-  model: HatchifyModel,
+  model: FinalSchema,
   associations: Record<string, IAssociation>,
   primaryKey: string,
 ): void {
@@ -140,7 +140,7 @@ export function registerSchema(
         ...acc,
         [associationName]: {
           type: model,
-          deserialize: (data) =>
+          deserialize: (data: { id: any } | null | undefined) =>
             data
               ? {
                   // Numeric IDs are passed as strings in JSON:API
@@ -151,7 +151,10 @@ export function registerSchema(
       }),
       {},
     ),
-    topLevelMeta: (_data, { unpaginatedCount }) =>
+    topLevelMeta: (
+      _data: any,
+      { unpaginatedCount }: { unpaginatedCount: any },
+    ) =>
       unpaginatedCount != null
         ? {
             unpaginatedCount,
@@ -161,11 +164,11 @@ export function registerSchema(
 }
 
 const serializeWithoutUnsolicitedVirtuals = (
-  hatchify,
-  array,
-  name,
-  attributes,
-  virtualsForModel,
+  hatchify: Hatchify,
+  array: any[],
+  name: string,
+  attributes: any[],
+  virtualsForModel: any[],
 ) => {
   return hatchify.serializer.serialize(
     name,

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "sourceMap": true,
-    "strict": false,
+    "strict": true,
     "strictNullChecks": true
   }
 }

--- a/packages/rest-client/tsconfig.json
+++ b/packages/rest-client/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "allowJs": true
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,11 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "paths": {
+      "@hatchifyjs/core": ["./packages/core"],
+      "@hatchifyjs/node": ["./packages/node"]
+    }
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
# Description
@hatchifyjs/node now validates the output of sequelize-querystring-parser for sort fields that exist on associated models.  A sort with a relationship has the form: `["relationshipName", "relationshipNameOnRelatedModel", ..., "attributeName", "ASC|DESC"]`
The validation code will look at the source schema and each related schema to ensure that the relationships and eventual attribute exist on the correct schemas, and throw an informative error when missing.

In addition, some structural changes have been made to hatchify code:
- The HatchifyModel type has been removed entirely.  It was causing too much confusion with the V2 schema -- things that should have been schemas in the code were models instead.
  -  new Hatchify(...).models contains the ORM models
  - new Hatchify(...).schema contains the Hatchify schema (FinalSchema) objects
- strict typing is now enabled for node and koa packages.  All types and typings have been updated to pass strict type checks, although some `any` and `any[]` has been necessary in places.
<!-- A more detailed multi-line description of the PR. -->

# Jira ticket links

[https://bitovi.atlassian.net/browse/HATCH-380](https://bitovi.atlassian.net/browse/HATCH-380)

# Test Plan

<!-- Step by step instructions on how to exercise the functionality you implemented. -->

# Definition of done

- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests? 86.75% node (
branches), 92.72% koa...
- [ ] Is code secure? If applicable, add security notes to the description.
- [ ] Do all new TODO comments have Jira links with enough information?
- [ ] Were all changes published and deployed to [the grid](https://github.com/bitovi/hatchify-grid-demo)?
- [ ] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
