### PR TITLE
hatch-350: changes in core v2 relationships for frontend type inference

### DIFF
--- a/packages/core/src/assembler/finalizeRelationships.ts
+++ b/packages/core/src/assembler/finalizeRelationships.ts
@@ -25,7 +25,7 @@ export function finalizeRelationships(
           if (relationship.type === "hasMany") {
             return finalizeHasMany(
               schemaName,
-              relationship as PartialHasManyRelationship,
+              relationship as PartialHasManyRelationship<string>, // @todo HATCH-417
               relationshipName,
               relationshipAcc,
             ) as Record<string, FinalSchema>

--- a/packages/core/src/relationships/belongsTo/finalize.ts
+++ b/packages/core/src/relationships/belongsTo/finalize.ts
@@ -4,9 +4,10 @@ import { HatchifyInvalidSchemaError } from "../../types"
 import type { SemiFinalSchema } from "../../types"
 import { camelCaseToPascalCase } from "../../util/camelCaseToPascalCase"
 
+// @todo HATCH-417
 export function finalize(
   sourceSchema: string,
-  relationship: PartialBelongsToRelationship,
+  relationship: PartialBelongsToRelationship<string | undefined | null>,
   relationshipName: string,
   schemas: Record<string, SemiFinalSchema>,
 ): Record<string, SemiFinalSchema> {

--- a/packages/core/src/relationships/belongsTo/index.ts
+++ b/packages/core/src/relationships/belongsTo/index.ts
@@ -1,15 +1,16 @@
 import type { PartialBelongsToRelationship } from "./types"
 
-export function belongsTo(
-  targetSchema?: string,
+// @todo HATCH-417
+export function belongsTo<TTargetSchema extends string | undefined | null>(
+  targetSchema?: TTargetSchema,
   props?: {
     sourceAttribute: string
     targetAttribute?: string
   },
-): PartialBelongsToRelationship {
+): PartialBelongsToRelationship<TTargetSchema> {
   return {
     type: "belongsTo",
-    targetSchema: targetSchema ?? null,
+    targetSchema: (targetSchema ?? null) as TTargetSchema,
     sourceAttribute: props?.sourceAttribute ?? null,
     targetAttribute: props?.targetAttribute ?? null,
   }

--- a/packages/core/src/relationships/belongsTo/types.ts
+++ b/packages/core/src/relationships/belongsTo/types.ts
@@ -1,6 +1,9 @@
-export interface PartialBelongsToRelationship {
+// @todo HATCH-417
+export interface PartialBelongsToRelationship<
+  TTargetSchema extends string | undefined | null,
+> {
   type: "belongsTo"
-  targetSchema: string | null
+  targetSchema: TTargetSchema
   sourceAttribute: string | null
   targetAttribute: string | null
 }

--- a/packages/core/src/relationships/hasMany/finalize.ts
+++ b/packages/core/src/relationships/hasMany/finalize.ts
@@ -7,9 +7,10 @@ import { pascalCaseToCamelCase } from "../../util/pascalCaseToCamelCase"
 import { singularize } from "../../util/singularize"
 import type { FinalRelationship, PartialRelationship } from "../types"
 
+// @todo HATCH-417
 export function finalize(
   sourceSchema: string,
-  relationship: PartialHasManyRelationship,
+  relationship: PartialHasManyRelationship<string | null | undefined>,
   relationshipName: string,
   schemas: Record<string, SemiFinalSchema>,
 ): Record<string, SemiFinalSchema> {

--- a/packages/core/src/relationships/hasMany/index.ts
+++ b/packages/core/src/relationships/hasMany/index.ts
@@ -1,18 +1,19 @@
 import type { PartialHasManyRelationship } from "./types"
 import { buildThrough } from "../hasManyThrough/buildThrough"
 
-export function hasMany(
-  schemaName?: string,
+// @todo HATCH-417
+export function hasMany<TTargetSchema extends string | undefined>(
+  schemaName?: TTargetSchema,
   props?: {
     targetAttribute: string
     sourceAttribute?: string
   },
-): PartialHasManyRelationship {
+): PartialHasManyRelationship<TTargetSchema> {
   const targetSchema = schemaName ?? null
 
   return {
     type: "hasMany",
-    targetSchema,
+    targetSchema: targetSchema as TTargetSchema,
     targetAttribute: props?.targetAttribute ?? null,
     sourceAttribute: props?.sourceAttribute ?? null,
     through: buildThrough(targetSchema),

--- a/packages/core/src/relationships/hasMany/types.ts
+++ b/packages/core/src/relationships/hasMany/types.ts
@@ -3,9 +3,12 @@ import type {
   ThroughOrAttributes,
 } from "../hasManyThrough/types"
 
-export interface PartialHasManyRelationship {
+// @todo HATCH-417
+export interface PartialHasManyRelationship<
+  TTargetSchema extends string | undefined | null,
+> {
   type: "hasMany"
-  targetSchema: string | null
+  targetSchema: TTargetSchema
   targetAttribute: string | null
   sourceAttribute: string | null
   through: (

--- a/packages/core/src/relationships/hasOne/finalize.ts
+++ b/packages/core/src/relationships/hasOne/finalize.ts
@@ -6,9 +6,10 @@ import { camelCaseToPascalCase } from "../../util/camelCaseToPascalCase"
 import { pascalCaseToCamelCase } from "../../util/pascalCaseToCamelCase"
 import type { FinalRelationship, PartialRelationship } from "../types"
 
+// @todo HATCH-417
 export function finalize(
   sourceSchema: string,
-  relationship: PartialHasOneRelationship,
+  relationship: PartialHasOneRelationship<string | null | undefined>,
   relationshipName: string,
   schemas: Record<string, SemiFinalSchema>,
 ): Record<string, SemiFinalSchema> {

--- a/packages/core/src/relationships/hasOne/index.ts
+++ b/packages/core/src/relationships/hasOne/index.ts
@@ -1,15 +1,16 @@
 import type { PartialHasOneRelationship } from "./types"
 
-export function hasOne(
-  targetSchema?: string,
+// @todo HATCH-417
+export function hasOne<TTargetSchema extends string | undefined>(
+  targetSchema?: TTargetSchema,
   props?: {
     targetAttribute: string
     sourceAttribute?: string
   },
-): PartialHasOneRelationship {
+): PartialHasOneRelationship<TTargetSchema> {
   return {
     type: "hasOne",
-    targetSchema: targetSchema ?? null,
+    targetSchema: (targetSchema ?? null) as TTargetSchema,
     targetAttribute: props?.targetAttribute ?? null,
     sourceAttribute: props?.sourceAttribute ?? null,
   }

--- a/packages/core/src/relationships/hasOne/types.ts
+++ b/packages/core/src/relationships/hasOne/types.ts
@@ -1,6 +1,9 @@
-export interface PartialHasOneRelationship {
+// @todo HATCH-417
+export interface PartialHasOneRelationship<
+  TTargetSchema extends string | undefined | null,
+> {
   type: "hasOne"
-  targetSchema: string | null
+  targetSchema: TTargetSchema
   targetAttribute: string | null
   sourceAttribute: string | null
 }

--- a/packages/core/src/relationships/types.ts
+++ b/packages/core/src/relationships/types.ts
@@ -15,9 +15,13 @@ import type {
   PartialHasOneRelationship,
 } from "./hasOne/types"
 
+// @todo HATCH-417
 export type PartialRelationship =
+  // @ts-expect-error
   | PartialBelongsToRelationship
+  // @ts-expect-error
   | PartialHasManyRelationship
+  // @ts-expect-error
   | PartialHasOneRelationship
   | PartialHasManyThroughRelationship
 


### PR DESCRIPTION
- made changes to core v2 relationships for required type inference for frontend strict typing
- these changes will be fixed in hatch-417 in a larger refactor/update of core schema v2 types