### PR TITLE
FE: Remove null as a possible value for result records on update

### DIFF
--- a/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
+++ b/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
@@ -39,7 +39,7 @@ export type ReactRest = {
     findAll: (
       query: QueryList,
     ) => Promise<[Records: Record[], Meta: RequestMetaData]>
-    updateOne: (data: UpdateData) => Promise<Record | null>
+    updateOne: (data: UpdateData) => Promise<Record>
     // hooks
     useCreateOne: () => [(data: CreateData) => void, Meta, Record?]
     useDeleteOne: () => [(id: string) => void, Meta]

--- a/packages/react-rest/src/services/useUpdateOne/useUpdateOne.test.ts
+++ b/packages/react-rest/src/services/useUpdateOne/useUpdateOne.test.ts
@@ -84,57 +84,6 @@ describe("react-rest/services/useUpdateOne", () => {
     )
   })
 
-  it("should return null if data source returns null", async () => {
-    createStore(["Article"])
-
-    fakeDataSource.updateOne = () => Promise.resolve(null)
-
-    const { result } = renderHook(() =>
-      useUpdateOne(fakeDataSource, schemas, "Article"),
-    )
-
-    await waitFor(() => {
-      expect(result.current).toEqual([
-        expect.any(Function),
-        {
-          status: "success",
-          meta: undefined,
-          error: undefined,
-          isDone: true,
-          isLoading: false,
-          isRejected: false,
-          isRevalidating: false,
-          isStale: false,
-          isSuccess: true,
-        },
-        undefined,
-      ])
-    })
-
-    await result.current[0]({
-      id: "1",
-      attributes: { title: "updated-title", body: "baz-body" },
-    })
-
-    await waitFor(() =>
-      expect(result.current).toEqual([
-        expect.any(Function),
-        {
-          status: "success",
-          meta: undefined,
-          error: undefined,
-          isDone: true,
-          isLoading: false,
-          isRejected: false,
-          isRevalidating: false,
-          isStale: false,
-          isSuccess: true,
-        },
-        null,
-      ]),
-    )
-  })
-
   it("should return an error if the request fails and clear it after success", async () => {
     createStore(["Article"])
 

--- a/packages/react-rest/src/services/useUpdateOne/useUpdateOne.ts
+++ b/packages/react-rest/src/services/useUpdateOne/useUpdateOne.ts
@@ -17,8 +17,8 @@ export const useUpdateOne = (
   dataSource: Source,
   allSchemas: Schemas,
   schemaName: string,
-): [(data: UpdateData) => void, Meta, Record | undefined | null] => {
-  const [data, setData] = useState<Record | undefined | null>(undefined)
+): [(data: UpdateData) => void, Meta, Record | undefined] => {
+  const [data, setData] = useState<Record | undefined>(undefined)
   const [error, setError] = useState<MetaError | undefined>(undefined)
   const [loading, setLoading] = useState<boolean>(false)
 

--- a/packages/rest-client-jsonapi/src/services/updateOne/updateOne.test.ts
+++ b/packages/rest-client-jsonapi/src/services/updateOne/updateOne.test.ts
@@ -58,24 +58,6 @@ describe("rest-client-jsonapi/services/updateOne", () => {
     expect(result).toEqual(expected)
   })
 
-  it("works if server returns null", async () => {
-    server.use(
-      rest.patch(`${baseUrl}/articles/article-id-1`, (_, res, ctx) =>
-        res.once(ctx.status(200), ctx.json({ data: null })),
-      ),
-    )
-
-    const data = {
-      __schema: "Article",
-      id: "article-id-1",
-      attributes: { title: "A new world!" },
-    }
-
-    const result = await updateOne(sourceConfig, schemaMap, "Article", data)
-
-    expect(result).toEqual(null)
-  })
-
   it("throws an error if the request fails", async () => {
     const errors = [
       {

--- a/packages/rest-client-jsonapi/src/services/updateOne/updateOne.ts
+++ b/packages/rest-client-jsonapi/src/services/updateOne/updateOne.ts
@@ -20,7 +20,7 @@ export async function updateOne(
   allSchemas: Schemas,
   schemaName: string,
   data: RestClientUpdateData,
-): Promise<Resource[] | null> {
+): Promise<Resource[]> {
   const jsonApiResource = hatchifyResourceToJsonApiResource(
     config,
     allSchemas[schemaName],
@@ -35,10 +35,6 @@ export async function updateOne(
     }`,
     jsonApiResource,
   )
-
-  if (!json.data) {
-    return Promise.resolve(null)
-  }
 
   return Promise.resolve(
     convertToHatchifyResources(

--- a/packages/rest-client/src/services/promise/updateOne/updateOne.test.ts
+++ b/packages/rest-client/src/services/promise/updateOne/updateOne.test.ts
@@ -23,16 +23,6 @@ describe("rest-client/services/promise/updateOne", () => {
     expect(result).toEqual(expected)
   })
 
-  it("should return null if data source returns null", async () => {
-    const nullDataSource = {
-      ...fakeDataSource,
-      updateOne: () => Promise.resolve(null),
-    }
-
-    const result = await updateOne(nullDataSource, schemas, "Article", data)
-    expect(result).toEqual(null)
-  })
-
   it.todo("should insert the record into the store")
 
   it.todo("should notify subscribers")

--- a/packages/rest-client/src/services/promise/updateOne/updateOne.ts
+++ b/packages/rest-client/src/services/promise/updateOne/updateOne.ts
@@ -11,14 +11,10 @@ export const updateOne = async (
   allSchemas: Schemas,
   schemaName: string,
   data: RestClientUpdateData, // todo: Resource or Record?
-): Promise<Record | null> => {
+): Promise<Record> => {
   const resources = await dataSource.updateOne(allSchemas, schemaName, data)
 
   notifySubscribers()
-
-  if (!resources) {
-    return null
-  }
 
   return flattenResourcesIntoRecords(allSchemas, resources, schemaName)[0]
 }

--- a/packages/rest-client/src/services/types/source.ts
+++ b/packages/rest-client/src/services/types/source.ts
@@ -57,7 +57,7 @@ export interface SourceV0 {
     allSchemas: Schemas,
     schemaName: string,
     data: RestClientUpdateData,
-  ) => Promise<Resource[] | null>
+  ) => Promise<Resource[]>
   deleteOne: (
     allSchemas: Schemas,
     schemaName: string,


### PR DESCRIPTION
<!-- The title of the PR should contain the ticket number and one line summary, ie HATCHXXX-1234: Ticket summary -->
<!-- For multiple tickets include multiple ticket numbers, ie HATCHXXX-1234, 4567: Summary of tickets -->

# Description

A follow up to #295 -- the frontend types and tests no longer have null as an option for update records
<!-- A more detailed multi-line description of the PR. -->

# Jira ticket links

<!-- Please add links to all Jira tickets that this PR concerns -->

# Test Plan

<!-- Step by step instructions on how to exercise the functionality you implemented. -->

# Definition of done

- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests?
- [ ] Is code secure? If applicable, add security notes to the description.
- [ ] Do all new TODO comments have Jira links with enough information?
- [ ] Were all changes published and deployed to [the grid](https://github.com/bitovi/hatchify-grid-demo)?
- [ ] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
