### PR TITLE
hatch-382: number filtering

### DIFF
--- a/packages/design-mui/package.json
+++ b/packages/design-mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/design-mui",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "./dist/design-mui.js",
   "module": "./dist/design-mui.mjs",
   "types": "./dist/design-mui.d.ts",

--- a/packages/design-mui/src/components/MuiAutocomplete/MuiAutocomplete.tsx
+++ b/packages/design-mui/src/components/MuiAutocomplete/MuiAutocomplete.tsx
@@ -6,12 +6,14 @@ export const MuiAutocomplete: React.FC<{
   options: string[]
   handleChange: (value: string[]) => void
   selectedOptions: string[]
+  textFieldType?: string
 }> = ({
   options,
   handleChange,
   selectedOptions,
   freeSolo = false,
   disableClearable = false,
+  textFieldType = "text",
 }) => {
   return (
     <Autocomplete
@@ -35,7 +37,12 @@ export const MuiAutocomplete: React.FC<{
         ))
       }
       renderInput={(params) => (
-        <TextField {...params} variant="standard" fullWidth />
+        <TextField
+          {...params}
+          variant="standard"
+          fullWidth
+          type={textFieldType}
+        />
       )}
       onChange={(e, value) => {
         handleChange(value)

--- a/packages/design-mui/src/components/MuiFilters/MuiFilters.test.tsx
+++ b/packages/design-mui/src/components/MuiFilters/MuiFilters.test.tsx
@@ -14,7 +14,7 @@ import {
 const partialSchemas = {
   Todo: {
     name: "Todo",
-    attributes: { id: integer(), name: string() },
+    attributes: { name: string(), id: integer() },
     relationships: { user: belongsTo() },
   },
   User: {

--- a/packages/design-mui/src/components/MuiFilters/MuiFilters.tsx
+++ b/packages/design-mui/src/components/MuiFilters/MuiFilters.tsx
@@ -1,11 +1,11 @@
-import type { XCollectionProps } from "@hatchifyjs/react-ui"
-import type { FilterArray } from "@hatchifyjs/rest-client"
 import { useCallback, useMemo, useRef, useState } from "react"
 import { Badge, Button, Grid, Popover, debounce } from "@mui/material"
-import { MuiFilterRows } from "./components/MuiFilterRows"
 import FilterListIcon from "@mui/icons-material/FilterList"
 import AddIcon from "@mui/icons-material/Add"
 import DeleteForeverIcon from "@mui/icons-material/DeleteForever"
+import type { XCollectionProps } from "@hatchifyjs/react-ui"
+import type { FilterArray } from "@hatchifyjs/rest-client"
+import { MuiFilterRows } from "./components/MuiFilterRows"
 import { getFilterableFields } from "./utils"
 
 export const MuiFilters: React.FC<XCollectionProps> = ({

--- a/packages/design-mui/src/components/MuiFilters/components/inputs/DateInput.tsx
+++ b/packages/design-mui/src/components/MuiFilters/components/inputs/DateInput.tsx
@@ -1,7 +1,8 @@
 import { TextField } from "@mui/material"
+import type { FilterableControls } from "../../constants"
 
 const DateInput: React.FC<{
-  controlType: string
+  controlType: FilterableControls
   labelId: string
   value: string
   onChange: (value: string) => void

--- a/packages/design-mui/src/components/MuiFilters/components/inputs/EnumInput.tsx
+++ b/packages/design-mui/src/components/MuiFilters/components/inputs/EnumInput.tsx
@@ -1,9 +1,10 @@
 import { MenuItem, Select } from "@mui/material"
 import MuiAutocomplete from "../../../MuiAutocomplete"
+import type { Operators } from "../../constants"
 
 const EnumInput: React.FC<{
   labelId: string
-  operator: string
+  operator: Operators
   value: string | string[]
   onChange: (value: any) => void
   options: string[]

--- a/packages/design-mui/src/components/MuiFilters/components/inputs/NumberInput.tsx
+++ b/packages/design-mui/src/components/MuiFilters/components/inputs/NumberInput.tsx
@@ -1,8 +1,8 @@
 import { TextField } from "@mui/material"
-import type { Operators } from "../../constants"
 import MuiAutocomplete from "../../../MuiAutocomplete/MuiAutocomplete"
+import type { Operators } from "../../constants"
 
-const StringInput: React.FC<{
+const NumberInput: React.FC<{
   labelId: string
   operator: Operators
   value: string | string[]
@@ -14,6 +14,7 @@ const StringInput: React.FC<{
       <MuiAutocomplete
         freeSolo
         disableClearable
+        textFieldType="number"
         options={options || []}
         selectedOptions={Array.isArray(value) ? (value as string[]) : []}
         handleChange={(value) => onChange(value)}
@@ -26,11 +27,11 @@ const StringInput: React.FC<{
       fullWidth
       placeholder="Filter Value"
       variant="standard"
-      type="text"
-      value={value as string}
+      type="number"
+      value={value}
       onChange={(e) => onChange(e.target.value)}
     />
   )
 }
 
-export default StringInput
+export default NumberInput

--- a/packages/design-mui/src/components/MuiFilters/components/inputs/OperatorSelect.tsx
+++ b/packages/design-mui/src/components/MuiFilters/components/inputs/OperatorSelect.tsx
@@ -1,7 +1,11 @@
 import { InputLabel, MenuItem, Select } from "@mui/material"
+import type {
+  OptionsByFilterableControls,
+  FilterableControls,
+} from "../../constants"
 
 const OperatorSelect: React.FC<{
-  options: Array<{ operator: string; text: string }>
+  options: OptionsByFilterableControls[FilterableControls]
   labelId: string
   value: string
   onChange: (value: string) => void

--- a/packages/design-mui/src/components/MuiFilters/components/inputs/ValueInput.tsx
+++ b/packages/design-mui/src/components/MuiFilters/components/inputs/ValueInput.tsx
@@ -1,13 +1,15 @@
 import { InputLabel } from "@mui/material"
+import type { FilterableControls, Operators } from "../../constants"
 import DateInput from "./DateInput"
 import EnumInput from "./EnumInput"
 import StringInput from "./StringInput"
+import NumberInput from "./NumberInput"
 
 const ValueInput: React.FC<{
   labelId: string
-  controlType: string
+  controlType: FilterableControls
+  operator: Operators
   value: any
-  operator: string
   onChange: (value: string | string[]) => void
   options?: string[]
 }> = ({ labelId, controlType, value, operator, onChange, options = [] }) => {
@@ -15,7 +17,6 @@ const ValueInput: React.FC<{
     return null
   }
 
-  console.log("fieldType", controlType)
   return (
     <>
       <InputLabel id={labelId}>Value</InputLabel>
@@ -42,6 +43,14 @@ const ValueInput: React.FC<{
           value={value}
           onChange={onChange}
           controlType={controlType}
+        />
+      )}
+      {controlType === "Number" && (
+        <NumberInput
+          labelId={labelId}
+          operator={operator}
+          value={value}
+          onChange={onChange}
         />
       )}
     </>

--- a/packages/design-mui/src/components/MuiFilters/constants.ts
+++ b/packages/design-mui/src/components/MuiFilters/constants.ts
@@ -1,0 +1,71 @@
+import type { FilterTypes } from "@hatchifyjs/rest-client"
+
+export type FilterableControls = (typeof filterableControlTypes)[number]
+
+export type Operators = "icontains" | "istarts" | "iends" | FilterTypes
+
+export interface Option {
+  operator: Operators
+  text: string
+}
+
+export type OptionsByFilterableControls = {
+  [key in FilterableControls]: Option[]
+}
+
+export const filterableControlTypes = [
+  "String",
+  "Number",
+  "Datetime",
+  "Dateonly",
+  "enum",
+] as const
+
+export const operatorOptionsByType: OptionsByFilterableControls = {
+  String: [
+    { operator: "icontains", text: "contains" },
+    { operator: "istarts", text: "starts with" },
+    { operator: "iends", text: "ends with" },
+    { operator: "$eq", text: "equals" },
+    { operator: "empty", text: "is empty" },
+    { operator: "nempty", text: "is not empty" },
+    { operator: "$in", text: "is any of" },
+  ],
+  Dateonly: [
+    { operator: "$eq", text: "is" },
+    { operator: "$gt", text: "is after" },
+    { operator: "$gte", text: "is on or after" },
+    { operator: "$lt", text: "is before" },
+    { operator: "$lte", text: "is on or before" },
+    { operator: "empty", text: "is empty" },
+    { operator: "nempty", text: "is not empty" },
+  ],
+  Datetime: [
+    { operator: "$eq", text: "is" },
+    { operator: "$gt", text: "is after" },
+    { operator: "$gte", text: "is on or after" },
+    { operator: "$lt", text: "is before" },
+    { operator: "$lte", text: "is on or before" },
+    { operator: "empty", text: "is empty" },
+    { operator: "nempty", text: "is not empty" },
+  ],
+  enum: [
+    { operator: "$eq", text: "is" },
+    { operator: "$ne", text: "is not" },
+    { operator: "empty", text: "is empty" },
+    { operator: "nempty", text: "is not empty" },
+    { operator: "$in", text: "is any of" },
+    { operator: "$nin", text: "is not any of" },
+  ],
+  Number: [
+    { operator: "$eq", text: "=" },
+    { operator: "$ne", text: "!=" },
+    { operator: "$gt", text: ">" },
+    { operator: "$gte", text: ">=" },
+    { operator: "$lt", text: "<" },
+    { operator: "$lte", text: "<=" },
+    { operator: "empty", text: "is empty" },
+    { operator: "nempty", text: "is not empty" },
+    { operator: "$in", text: "is any of" },
+  ],
+}

--- a/packages/design-mui/src/components/MuiFilters/utils/utils.tsx
+++ b/packages/design-mui/src/components/MuiFilters/utils/utils.tsx
@@ -1,4 +1,5 @@
 import type { XCollectionProps } from "@hatchifyjs/react-ui"
+import { filterableControlTypes } from "../constants"
 
 type HatchifyMuiFilters = string[]
 
@@ -9,13 +10,8 @@ export function getFilterableFields(
 ): HatchifyMuiFilters {
   // get all filterable fields from the base schema
   const fields = Object.entries(allSchemas[schemaName].attributes)
-    // todo: filtering should not rely on UUID type because it may still be an attribute
     .filter(([, { control }]) => control.hidden !== true)
-    .filter(([, { control }]) =>
-      ["string", "date", "dateonly", "datetime", "enum"].includes(
-        control.type.toLowerCase(),
-      ),
-    )
+    .filter(([, { control }]) => filterableControlTypes.includes(control.type))
     .map(([key]) => key)
 
   // get related schemas that are part of the include
@@ -35,9 +31,7 @@ export function getFilterableFields(
     )
       .filter(([, { control }]) => control.hidden !== true)
       .filter(([, { control }]) =>
-        ["string", "date", "dateonly", "datetime", "enum"].includes(
-          control.type.toLowerCase(),
-        ),
+        filterableControlTypes.includes(control.type),
       )
       .map(([key]) => `${includedRelationships[i].relationship}.${key}`)
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "./dist/react.js",
   "module": "./dist/react.mjs",
   "types": "./dist/react.d.ts",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@hatchifyjs/core": "^0.2.9",
-    "@hatchifyjs/design-mui": "^0.1.13",
+    "@hatchifyjs/design-mui": "^0.1.14",
     "@hatchifyjs/react-ui": "^0.1.9",
     "@hatchifyjs/rest-client-jsonapi": "^0.1.7"
   },


### PR DESCRIPTION
- enable filtering for control type "number"
- refactored types & consts around mui filter components
- rest-client/filter and design-mui/filter types should be refactored as part of hatch-417

https://bitovi.atlassian.net/browse/HATCH-382
