### PR TITLE
hatch-388: skip related columns that are not included

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18549,9 +18549,9 @@
     },
     "packages/design-mui": {
       "name": "@hatchifyjs/design-mui",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
-        "@hatchifyjs/react-ui": "^0.1.15",
+        "@hatchifyjs/react-ui": "^0.1.16",
         "@mui/icons-material": "^5.14.1",
         "@mui/utils": "^5.13.1",
         "lodash": "^4.17.21"
@@ -18696,10 +18696,10 @@
     },
     "packages/react": {
       "name": "@hatchifyjs/react",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
-        "@hatchifyjs/design-mui": "^0.1.20",
-        "@hatchifyjs/react-ui": "^0.1.15",
+        "@hatchifyjs/design-mui": "^0.1.21",
+        "@hatchifyjs/react-ui": "^0.1.16",
         "@hatchifyjs/rest-client-jsonapi": "^0.1.10"
       },
       "devDependencies": {
@@ -18760,7 +18760,7 @@
     },
     "packages/react-ui": {
       "name": "@hatchifyjs/react-ui",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@hatchifyjs/react-rest": "^0.1.10",
         "@hatchifyjs/rest-client": "^0.1.8"

--- a/packages/design-mui/package.json
+++ b/packages/design-mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/design-mui",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "main": "./dist/design-mui.js",
   "module": "./dist/design-mui.mjs",
   "types": "./dist/design-mui.d.ts",
@@ -36,7 +36,7 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@hatchifyjs/react-ui": "^0.1.15",
+    "@hatchifyjs/react-ui": "^0.1.16",
     "@mui/icons-material": "^5.14.1",
     "@mui/utils": "^5.13.1",
     "lodash": "^4.17.21"

--- a/packages/design-mui/src/components/MuiList/MuiList.tsx
+++ b/packages/design-mui/src/components/MuiList/MuiList.tsx
@@ -15,12 +15,13 @@ const styles = {
 
 export function MuiList<
   const TSchemas extends Record<string, PartialSchema> = any,
-  const TSchemaNames extends GetSchemaNames<TSchemas> = any,
->(props: XCollectionProps<TSchemas, TSchemaNames>): JSX.Element {
+  const TSchemaName extends GetSchemaNames<TSchemas> = any,
+>(props: XCollectionProps<TSchemas, TSchemaName>): JSX.Element {
   const { columns, Empty } = useCompoundComponents(
     props.finalSchemas,
     props.schemaName,
     props.children,
+    props.include,
   )
 
   return (

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react-ui",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "./dist/react-ui.js",
   "module": "./dist/react-ui.mjs",
   "types": "./dist/react-ui.d.ts",

--- a/packages/react-ui/src/hooks/useCollectionState.ts
+++ b/packages/react-ui/src/hooks/useCollectionState.ts
@@ -43,7 +43,7 @@ export interface CollectionState<
   setSelected: HatchifyCollectionSelected["setSelected"] | undefined
   finalSchemas: FinalSchemas
   partialSchemas: TSchemas
-  schemaName: string
+  schemaName: TSchemaName
 }
 
 export default function useCollectionState<

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.tsx
@@ -1,11 +1,15 @@
 import { uuidv4 } from "@hatchifyjs/core"
+import type { PartialSchema } from "@hatchifyjs/core"
 import type { FinalAttributeRecord } from "@hatchifyjs/core"
-import type { FinalSchemas } from "@hatchifyjs/rest-client"
+import type { FinalSchemas, GetSchemaNames } from "@hatchifyjs/rest-client"
 import type { DefaultValueComponentsTypes } from "../../../components"
 import type { HatchifyColumn } from "../useCompoundComponents"
 import { getDefaultColumnRender } from "."
 
-export function getColumn({
+export function getColumn<
+  const TSchemas extends globalThis.Record<string, PartialSchema>,
+  const TSchemaName extends GetSchemaNames<TSchemas>,
+>({
   finalSchemas,
   schemaName,
   control,
@@ -15,7 +19,7 @@ export function getColumn({
   defaultValueComponents,
 }: {
   finalSchemas: FinalSchemas
-  schemaName: string
+  schemaName: TSchemaName
   control?: FinalAttributeRecord[string]["control"] | null
   field: string
   compoundComponentProps: any
@@ -56,7 +60,7 @@ export function getColumn({
   } else {
     column.render = getDefaultColumnRender({
       finalSchemas,
-      schemaName,
+      schemaName: schemaName as string,
       control,
       field: field,
       isRelationship: isRelationship === true,

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.test.ts
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.test.ts
@@ -11,7 +11,7 @@ import { HatchifyPresentationDefaultValueComponents } from "../../../components"
 import { getColumns } from "."
 
 describe("hooks/useCompoundComponents/helpers/getColumns", () => {
-  const finalSchemas = assembler({
+  const partialSchemas = {
     Todo: {
       name: "Todo",
       attributes: {
@@ -32,7 +32,8 @@ describe("hooks/useCompoundComponents/helpers/getColumns", () => {
         todos: hasMany("Todo"),
       },
     },
-  })
+  }
+  const finalSchemas = assembler(partialSchemas)
 
   it("works with no children", () => {
     expect(
@@ -41,6 +42,35 @@ describe("hooks/useCompoundComponents/helpers/getColumns", () => {
         "Todo",
         HatchifyPresentationDefaultValueComponents,
         [],
+      ),
+    ).toEqual([
+      {
+        key: "title",
+        label: "Title",
+        render: expect.any(Function),
+        sortable: true,
+      },
+      {
+        key: "created",
+        label: "Created",
+        render: expect.any(Function),
+        sortable: true,
+      },
+      {
+        key: "important",
+        label: "Important",
+        render: expect.any(Function),
+        sortable: true,
+      },
+    ])
+
+    expect(
+      getColumns<typeof partialSchemas, "Todo">(
+        finalSchemas,
+        "Todo",
+        HatchifyPresentationDefaultValueComponents,
+        [],
+        ["user"],
       ),
     ).toEqual([
       {

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.ts
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.ts
@@ -1,16 +1,26 @@
-import type { FinalSchemas } from "@hatchifyjs/rest-client"
+import type { PartialSchema } from "@hatchifyjs/core"
+import type {
+  FinalSchemas,
+  GetSchemaFromName,
+  GetSchemaNames,
+  Include,
+} from "@hatchifyjs/rest-client"
 import type { HatchifyColumn } from "../useCompoundComponents"
 import type { DefaultValueComponentsTypes } from "../../../components"
 import { getColumn, getColumnsFromSchema } from "."
 
-export function getColumns(
+export function getColumns<
+  const TSchemas extends globalThis.Record<string, PartialSchema>,
+  const TSchemaName extends GetSchemaNames<TSchemas>,
+>(
   finalSchemas: FinalSchemas,
-  schemaName: string,
+  schemaName: TSchemaName,
   valueComponents: DefaultValueComponentsTypes,
   childArray: JSX.Element[],
+  include?: Include<GetSchemaFromName<TSchemas, TSchemaName>>,
 ): HatchifyColumn[] {
   const hatchifyColumns: HatchifyColumn[] = []
-  const schema = finalSchemas[schemaName]
+  const schema = finalSchemas[schemaName as string]
 
   const columns = childArray.filter((c) => c.type.name === "Column")
   const prepend = columns.filter((c) => c.props.type === "prepend")
@@ -20,7 +30,7 @@ export function getColumns(
 
   const getHatchifyColumnCommon = {
     finalSchemas,
-    schemaName,
+    schemaName: schemaName as string,
     defaultValueComponents: valueComponents,
   }
 
@@ -60,6 +70,7 @@ export function getColumns(
       finalSchemas,
       schemaName,
       valueComponents,
+      include,
     )
 
     for (let i = 0; i < schemaColumns.length; i++) {

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumnsFromSchema.test.ts
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumnsFromSchema.test.ts
@@ -11,7 +11,7 @@ import { HatchifyPresentationDefaultValueComponents } from "../../../components"
 import { getColumnsFromSchema } from "."
 
 describe("hooks/useCompoundComponents/helpers/getColumnsFromSchema", () => {
-  const finalSchemas = assembler({
+  const partialSchemas = {
     Todo: {
       name: "Todo",
       attributes: {
@@ -32,7 +32,8 @@ describe("hooks/useCompoundComponents/helpers/getColumnsFromSchema", () => {
         todos: hasMany("Todo"),
       },
     },
-  })
+  }
+  const finalSchemas = assembler(partialSchemas)
 
   it("works", () => {
     expect(
@@ -40,6 +41,34 @@ describe("hooks/useCompoundComponents/helpers/getColumnsFromSchema", () => {
         finalSchemas,
         "Todo",
         HatchifyPresentationDefaultValueComponents,
+      ),
+    ).toEqual([
+      {
+        key: "title",
+        label: "Title",
+        render: expect.any(Function),
+        sortable: true,
+      },
+      {
+        key: "created",
+        label: "Created",
+        render: expect.any(Function),
+        sortable: true,
+      },
+      {
+        key: "important",
+        label: "Important",
+        render: expect.any(Function),
+        sortable: true,
+      },
+    ])
+
+    expect(
+      getColumnsFromSchema<typeof partialSchemas, "Todo">(
+        finalSchemas,
+        "Todo",
+        HatchifyPresentationDefaultValueComponents,
+        ["user"],
       ),
     ).toEqual([
       {

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getDefaultColumnRender.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getDefaultColumnRender.tsx
@@ -1,8 +1,15 @@
-import type { FinalAttributeRecord } from "@hatchifyjs/core"
-import type { FinalSchemas, Record } from "@hatchifyjs/rest-client"
+import type { FinalAttributeRecord, PartialSchema } from "@hatchifyjs/core"
+import type {
+  FinalSchemas,
+  GetSchemaNames,
+  Record,
+} from "@hatchifyjs/rest-client"
 import type { DefaultValueComponentsTypes } from "../../../components"
 
-export function getDefaultColumnRender({
+export function getDefaultColumnRender<
+  const TSchemas extends globalThis.Record<string, PartialSchema>,
+  const TSchemaName extends GetSchemaNames<TSchemas>,
+>({
   finalSchemas,
   schemaName,
   control,
@@ -12,7 +19,7 @@ export function getDefaultColumnRender({
   defaultValueComponents,
 }: {
   finalSchemas: FinalSchemas
-  schemaName: string
+  schemaName: TSchemaName
   control: FinalAttributeRecord[string]["control"]
   field: string
   isRelationship: boolean

--- a/packages/react-ui/src/hooks/useCompoundComponents/useCompoundComponents.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/useCompoundComponents.tsx
@@ -1,5 +1,12 @@
 import { Children as ReactChildren } from "react"
-import type { FinalSchemas, Record } from "@hatchifyjs/rest-client"
+import type { PartialSchema } from "@hatchifyjs/core"
+import type {
+  FinalSchemas,
+  GetSchemaFromName,
+  GetSchemaNames,
+  Include,
+  Record,
+} from "@hatchifyjs/rest-client"
 import { useHatchifyPresentation } from "../../components"
 import { getColumns, getEmptyList } from "./helpers"
 
@@ -15,16 +22,26 @@ interface CompoundComponents {
   Empty: () => JSX.Element
 }
 
-export default function useCompoundComponents(
+export default function useCompoundComponents<
+  const TSchemas extends globalThis.Record<string, PartialSchema>,
+  const TSchemaName extends GetSchemaNames<TSchemas>,
+>(
   finalSchemas: FinalSchemas,
-  schemaName: string,
+  schemaName: TSchemaName,
   children: React.ReactNode | null,
+  include?: Include<GetSchemaFromName<TSchemas, TSchemaName>>,
 ): CompoundComponents {
   const childArray = ReactChildren.toArray(children) as JSX.Element[]
   const valueComponents = useHatchifyPresentation().defaultValueComponents
 
   return {
-    columns: getColumns(finalSchemas, schemaName, valueComponents, childArray),
+    columns: getColumns(
+      finalSchemas,
+      schemaName,
+      valueComponents,
+      childArray,
+      include,
+    ),
     Empty: getEmptyList(childArray),
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "./dist/react.js",
   "module": "./dist/react.mjs",
   "types": "./dist/react.d.ts",
@@ -24,8 +24,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hatchifyjs/design-mui": "^0.1.20",
-    "@hatchifyjs/react-ui": "^0.1.15",
+    "@hatchifyjs/design-mui": "^0.1.21",
+    "@hatchifyjs/react-ui": "^0.1.16",
     "@hatchifyjs/rest-client-jsonapi": "^0.1.10"
   },
   "devDependencies": {


### PR DESCRIPTION
- when determining default columns for table from schema, skip to-one relationship columns that are not part of the include query (`collectionState` being spread into ejected components)

https://bitovi.atlassian.net/browse/HATCH-388