### PR TITLE
fix: filter rerender bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18549,9 +18549,9 @@
     },
     "packages/design-mui": {
       "name": "@hatchifyjs/design-mui",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
-        "@hatchifyjs/react-ui": "^0.1.19",
+        "@hatchifyjs/react-ui": "^0.1.20",
         "@mui/icons-material": "^5.14.1",
         "@mui/utils": "^5.13.1",
         "lodash": "^4.17.21"
@@ -18696,10 +18696,10 @@
     },
     "packages/react": {
       "name": "@hatchifyjs/react",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
-        "@hatchifyjs/design-mui": "^0.1.25",
-        "@hatchifyjs/react-ui": "^0.1.19",
+        "@hatchifyjs/design-mui": "^0.1.27",
+        "@hatchifyjs/react-ui": "^0.1.20",
         "@hatchifyjs/rest-client-jsonapi": "^0.1.11"
       },
       "devDependencies": {
@@ -18760,7 +18760,7 @@
     },
     "packages/react-ui": {
       "name": "@hatchifyjs/react-ui",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "dependencies": {
         "@hatchifyjs/react-rest": "^0.1.11",
         "@hatchifyjs/rest-client": "^0.1.9"

--- a/packages/design-mui/package.json
+++ b/packages/design-mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/design-mui",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "main": "./dist/design-mui.js",
   "module": "./dist/design-mui.mjs",
   "types": "./dist/design-mui.d.ts",
@@ -36,7 +36,7 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@hatchifyjs/react-ui": "^0.1.19",
+    "@hatchifyjs/react-ui": "^0.1.20",
     "@mui/icons-material": "^5.14.1",
     "@mui/utils": "^5.13.1",
     "lodash": "^4.17.21"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react-ui",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "./dist/react-ui.js",
   "module": "./dist/react-ui.mjs",
   "types": "./dist/react-ui.d.ts",

--- a/packages/react-ui/src/components/HatchifyCollection/HatchifyCollection.tsx
+++ b/packages/react-ui/src/components/HatchifyCollection/HatchifyCollection.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react"
 import type {
   Filters,
   PaginationObject,
@@ -44,9 +45,14 @@ function HatchifyCollection<
   baseFilter,
 }: HatchifyCollectionProps<TSchemas, TSchemaName>): JSX.Element {
   const { Collection } = useHatchifyPresentation()
-  const defaultInclude = getDefaultInclude<
-    GetSchemaFromName<TSchemas, TSchemaName>
-  >(finalSchemas, schemaName as string)
+  const defaultInclude = useMemo(
+    () =>
+      getDefaultInclude<GetSchemaFromName<TSchemas, TSchemaName>>(
+        finalSchemas,
+        schemaName as string,
+      ),
+    [finalSchemas, schemaName],
+  )
 
   const collectionState = useCollectionState(
     finalSchemas,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "main": "./dist/react.js",
   "module": "./dist/react.mjs",
   "types": "./dist/react.d.ts",
@@ -24,8 +24,8 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hatchifyjs/design-mui": "^0.1.25",
-    "@hatchifyjs/react-ui": "^0.1.19",
+    "@hatchifyjs/design-mui": "^0.1.27",
+    "@hatchifyjs/react-ui": "^0.1.20",
     "@hatchifyjs/rest-client-jsonapi": "^0.1.11"
   },
   "devDependencies": {


### PR DESCRIPTION
- fix filter re-render by wrapping `defaultInclude` in a `useMemo` to avoid multiple re-renders when filter callback fires