### PR TITLE
hatch-499: fix remounts for renderDataValue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19598,9 +19598,9 @@
     },
     "packages/design-mui": {
       "name": "@hatchifyjs/design-mui",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "dependencies": {
-        "@hatchifyjs/react-ui": "^0.1.27",
+        "@hatchifyjs/react-ui": "0.1.28",
         "@mui/icons-material": "^5.14.1",
         "@mui/utils": "^5.13.1",
         "lodash": "^4.17.21"
@@ -19718,11 +19718,11 @@
     },
     "packages/react": {
       "name": "@hatchifyjs/react",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "dependencies": {
-        "@hatchifyjs/design-mui": "^0.1.37",
-        "@hatchifyjs/react-ui": "^0.1.27",
-        "@hatchifyjs/rest-client-jsonapi": "^0.1.15"
+        "@hatchifyjs/design-mui": "0.1.38",
+        "@hatchifyjs/react-ui": "0.1.28",
+        "@hatchifyjs/rest-client-jsonapi": "0.1.16"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -19741,11 +19741,11 @@
     },
     "packages/react-jsonapi": {
       "name": "@hatchifyjs/react-jsonapi",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@hatchifyjs/react-rest": "^0.1.15",
-        "@hatchifyjs/rest-client": "^0.1.12",
-        "@hatchifyjs/rest-client-jsonapi": "^0.1.15"
+        "@hatchifyjs/react-rest": "0.1.16",
+        "@hatchifyjs/rest-client": "0.1.12",
+        "@hatchifyjs/rest-client-jsonapi": "0.1.16"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -19761,9 +19761,9 @@
     },
     "packages/react-rest": {
       "name": "@hatchifyjs/react-rest",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
-        "@hatchifyjs/rest-client": "^0.1.12"
+        "@hatchifyjs/rest-client": "0.1.12"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -19782,10 +19782,10 @@
     },
     "packages/react-ui": {
       "name": "@hatchifyjs/react-ui",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "dependencies": {
-        "@hatchifyjs/react-rest": "^0.1.15",
-        "@hatchifyjs/rest-client": "^0.1.12"
+        "@hatchifyjs/react-rest": "0.1.16",
+        "@hatchifyjs/rest-client": "0.1.12"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -19822,9 +19822,9 @@
     },
     "packages/rest-client-jsonapi": {
       "name": "@hatchifyjs/rest-client-jsonapi",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
-        "@hatchifyjs/rest-client": "^0.1.12"
+        "@hatchifyjs/rest-client": "0.1.12"
       },
       "devDependencies": {
         "@hatchifyjs/koa": "^1.0.2",

--- a/packages/design-mui/package.json
+++ b/packages/design-mui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/design-mui",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "main": "./dist/design-mui.js",
   "module": "./dist/design-mui.mjs",
   "types": "./dist/design-mui.d.ts",
@@ -37,7 +37,7 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@hatchifyjs/react-ui": "^0.1.27",
+    "@hatchifyjs/react-ui": "0.1.28",
     "@mui/icons-material": "^5.14.1",
     "@mui/utils": "^5.13.1",
     "lodash": "^4.17.21"

--- a/packages/react-jsonapi/package.json
+++ b/packages/react-jsonapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react-jsonapi",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "./dist/react-jsonapi.js",
   "module": "./dist/react-jsonapi.mjs",
   "types": "./dist/react-jsonapi.d.ts",
@@ -25,9 +25,9 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hatchifyjs/react-rest": "^0.1.15",
-    "@hatchifyjs/rest-client": "^0.1.12",
-    "@hatchifyjs/rest-client-jsonapi": "^0.1.15"
+    "@hatchifyjs/react-rest": "0.1.16",
+    "@hatchifyjs/rest-client": "0.1.12",
+    "@hatchifyjs/rest-client-jsonapi": "0.1.16"
   },
   "peerDependencies": {
     "@hatchifyjs/core": "^0.3.x"

--- a/packages/react-rest/package.json
+++ b/packages/react-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react-rest",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "./dist/react-rest.js",
   "module": "./dist/react-rest.mjs",
   "types": "./dist/react-rest.d.ts",
@@ -25,7 +25,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hatchifyjs/rest-client": "^0.1.12"
+    "@hatchifyjs/rest-client": "0.1.12"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react-ui",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "main": "./dist/react-ui.js",
   "module": "./dist/react-ui.mjs",
   "types": "./dist/react-ui.d.ts",
@@ -35,8 +35,8 @@
     "vitest": "^0.30.1"
   },
   "dependencies": {
-    "@hatchifyjs/react-rest": "^0.1.15",
-    "@hatchifyjs/rest-client": "^0.1.12"
+    "@hatchifyjs/react-rest": "0.1.16",
+    "@hatchifyjs/rest-client": "0.1.12"
   },
   "peerDependencies": {
     "@hatchifyjs/core": "^0.3.x",

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.test.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.test.tsx
@@ -39,6 +39,7 @@ describe("hooks/useCompoundComponents/helpers/getColumn", () => {
       finalSchemas: finalSchemas,
       schemaName: "Todo",
       field: "title",
+      key: "title",
       control: finalSchemas.Todo.attributes.title.control,
       compoundComponentProps: {},
       defaultValueComponents: HatchifyPresentationDefaultValueComponents,
@@ -59,6 +60,7 @@ describe("hooks/useCompoundComponents/helpers/getColumn", () => {
       finalSchemas: finalSchemas,
       schemaName: "Todo",
       field: "created",
+      key: "created",
       control: finalSchemas.Todo.attributes.created.control,
       compoundComponentProps: {
         label: "CREATED",
@@ -81,6 +83,7 @@ describe("hooks/useCompoundComponents/helpers/getColumn", () => {
       finalSchemas: finalSchemas,
       schemaName: "Todo",
       field: "title",
+      key: "title",
       control: finalSchemas.Todo.attributes.created.control,
       compoundComponentProps: {
         renderHeaderValue: () => null,
@@ -103,6 +106,7 @@ describe("hooks/useCompoundComponents/helpers/getColumn", () => {
       finalSchemas: finalSchemas,
       schemaName: "Todo",
       field: "",
+      key: "additional-0",
       control: null,
       compoundComponentProps: { label: "Additional Column" },
       defaultValueComponents: HatchifyPresentationDefaultValueComponents,
@@ -111,7 +115,7 @@ describe("hooks/useCompoundComponents/helpers/getColumn", () => {
     expect(column).toEqual({
       headerOverride: false,
       sortable: false,
-      key: column.key,
+      key: "additional-0",
       label: "Additional Column",
       renderData: expect.any(Function),
       renderHeader: expect.any(Function),
@@ -122,6 +126,7 @@ describe("hooks/useCompoundComponents/helpers/getColumn", () => {
     const column = getColumn({
       finalSchemas: finalSchemas,
       schemaName: "Todo",
+      key: "user",
       field: "user",
       control: null,
       compoundComponentProps: {},

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.tsx
@@ -17,6 +17,7 @@ export function getColumn<
   isRelationship,
   defaultValueComponents,
   sortable,
+  key
 }: {
   finalSchemas: FinalSchemas
   schemaName: TSchemaName
@@ -26,6 +27,7 @@ export function getColumn<
   isRelationship?: boolean
   defaultValueComponents: DefaultValueComponentsTypes
   sortable?: boolean
+  key: string
 }): HatchifyColumn {
   const {
     label: labelProp,
@@ -42,7 +44,7 @@ export function getColumn<
   const column: HatchifyColumn = {
     sortable:
       sortable !== undefined ? sortable : !isAdditional && !isRelationship, // reference sortable prop; otherwise sortable if an attribute
-    key: field || uuidv4(), // if no field, then it's an additional column, but needs a key?
+    key,
     label,
     renderData: () => null, // default render so TS doesn't complain
     renderHeader: () => null, // default render so TS doesn't complain

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumn.tsx
@@ -1,4 +1,3 @@
-import { uuidv4 } from "@hatchifyjs/core"
 import type { PartialSchema, FinalAttributeRecord } from "@hatchifyjs/core"
 import type { FinalSchemas, GetSchemaNames } from "@hatchifyjs/rest-client"
 import type { DefaultValueComponentsTypes } from "../../../components"
@@ -17,7 +16,7 @@ export function getColumn<
   isRelationship,
   defaultValueComponents,
   sortable,
-  key
+  key,
 }: {
   finalSchemas: FinalSchemas
   schemaName: TSchemaName

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.ts
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.ts
@@ -36,11 +36,13 @@ export function getColumns<
 
   for (let i = 0; i < prepend.length; i++) {
     const { props } = prepend[i]
+
     hatchifyColumns.push(
       getColumn({
         ...getHatchifyColumnCommon,
         control: null,
         field: "",
+        key: `prepend-${i}`,
         compoundComponentProps: props,
         isRelationship: false,
       }),
@@ -61,6 +63,7 @@ export function getColumns<
             ? null
             : schema.attributes?.[props.field]?.control || null,
           field: validField ? props.field : "",
+          key: validField ? props.field : `overwrite-${i}`,
           compoundComponentProps: props,
           isRelationship: relationship !== undefined,
           sortable: props.sortable,
@@ -92,6 +95,7 @@ export function getColumns<
               ? null
               : schema.attributes?.[props.field]?.control || null,
             field: props.field,
+            key: props.field,
             compoundComponentProps: props,
             isRelationship: relationship !== undefined,
             sortable: props.sortable,
@@ -105,11 +109,13 @@ export function getColumns<
 
   for (let i = 0; i < append.length; i++) {
     const { props } = append[i]
+
     hatchifyColumns.push(
       getColumn({
         ...getHatchifyColumnCommon,
         control: null,
         field: "",
+        key: `append-${i}`,
         compoundComponentProps: props,
         isRelationship: false,
       }),

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumnsFromSchema.ts
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumnsFromSchema.ts
@@ -30,6 +30,7 @@ export function getColumnsFromSchema<
         control,
         field: attributeName,
         isRelationship: false,
+        key: attributeName,
         compoundComponentProps: {},
       })
     })
@@ -52,6 +53,7 @@ export function getColumnsFromSchema<
         defaultValueComponents,
         control: null,
         field: key,
+        key,
         isRelationship: true,
         compoundComponentProps: {},
       })

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/react",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "main": "./dist/react.js",
   "module": "./dist/react.mjs",
   "types": "./dist/react.d.ts",
@@ -25,9 +25,9 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hatchifyjs/design-mui": "^0.1.37",
-    "@hatchifyjs/react-ui": "^0.1.27",
-    "@hatchifyjs/rest-client-jsonapi": "^0.1.15"
+    "@hatchifyjs/design-mui": "0.1.38",
+    "@hatchifyjs/react-ui": "0.1.28",
+    "@hatchifyjs/rest-client-jsonapi": "0.1.16"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/packages/rest-client-jsonapi/package.json
+++ b/packages/rest-client-jsonapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hatchifyjs/rest-client-jsonapi",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "./dist/rest-client-jsonapi.js",
   "module": "./dist/rest-client-jsonapi.mjs",
   "types": "./dist/rest-client-jsonapi.d.ts",
@@ -25,7 +25,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@hatchifyjs/rest-client": "^0.1.12"
+    "@hatchifyjs/rest-client": "0.1.12"
   },
   "devDependencies": {
     "@hatchifyjs/koa": "^1.0.2",


### PR DESCRIPTION
- compoundComponents for append/prepend were falling back to `uuidv4()` as keys
- `uuidv4()` was generating a unique key whenever the list rerendered which would remount the components returned in `renderDataValue`
- removed `uuidv4()` and set `key` to a more stable value