### PR TITLE
break crypto dependency into isomorphic package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1577,6 +1577,10 @@
       "resolved": "packages/create",
       "link": true
     },
+    "node_modules/@hatchifyjs/crypto": {
+      "resolved": "packages/crypto",
+      "link": true
+    },
     "node_modules/@hatchifyjs/design-mui": {
       "resolved": "packages/design-mui",
       "link": true
@@ -17771,6 +17775,9 @@
     "packages/core": {
       "name": "@hatchifyjs/core",
       "version": "0.3.13",
+      "dependencies": {
+        "@hatchifyjs/crypto": "^1.0.0"
+      },
       "devDependencies": {
         "@bitovi/eslint-config": "^1.6.0",
         "@jest/globals": "^29.7.0",
@@ -18707,6 +18714,11 @@
           "optional": true
         }
       }
+    },
+    "packages/crypto": {
+      "name": "@hatchifyjs/crypto",
+      "version": "1.0.0",
+      "license": "ISC"
     },
     "packages/design-mui": {
       "name": "@hatchifyjs/design-mui",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,9 @@
     "clean": "rm -rf tsconfig.tsbuildinfo dist",
     "build": "tsc"
   },
+  "dependencies": {
+    "@hatchifyjs/crypto": "^1.0.0"
+  },
   "devDependencies": {
     "@bitovi/eslint-config": "^1.6.0",
     "@jest/globals": "^29.7.0",

--- a/packages/core/src/util/uuidv4.ts
+++ b/packages/core/src/util/uuidv4.ts
@@ -1,10 +1,1 @@
-/* istanbul ignore next */
-const crypto = globalThis.crypto || (await import("node:crypto")).webcrypto
-
-export function getCrypto() {
-  return crypto
-}
-
-export function uuidv4(): string {
-  return crypto.randomUUID()
-}
+export * from "@hatchifyjs/crypto"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,6 +4,9 @@
     "rootDir": "./src"
   },
   "extends": "../../tsconfig.json",
-  "include": ["src", "src/core.ts"]
+  "include": [
+    "src",
+    "src/core.ts"
+  ]
 }
  

--- a/packages/crypto/index.browser.js
+++ b/packages/crypto/index.browser.js
@@ -1,0 +1,7 @@
+export function getCrypto() {
+  return window.crypto
+}
+
+export function uuidv4() {
+  return window.crypto.randomUUID()
+}

--- a/packages/crypto/index.d.ts
+++ b/packages/crypto/index.d.ts
@@ -1,0 +1,5 @@
+declare module "@hatchifyjs/crypto"
+
+export declare function getCrypto(): Crypto
+
+export declare function uuidv4(): string

--- a/packages/crypto/index.js
+++ b/packages/crypto/index.js
@@ -1,0 +1,9 @@
+import crypto from "node:crypto"
+
+export function getCrypto() {
+  return crypto.webcrypto
+}
+
+export function uuidv4() {
+  return crypto.webcrypto.randomUUID()
+}

--- a/packages/crypto/index.spec.js
+++ b/packages/crypto/index.spec.js
@@ -1,8 +1,8 @@
 import crypto from "node:crypto"
 
-import { getCrypto, uuidv4 } from "./uuidv4.js"
+import { getCrypto, uuidv4 } from "./index.js"
 
-describe("uuidv4", () => {
+describe("crypto", () => {
   it("generates a uuid", () => {
     expect(uuidv4()).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@hatchifyjs/crypto",
+  "version": "1.0.0",
+  "description": "Isomorphic WebCrypto package. Only Isomorphic. No Polyfills.",
+  "type": "module",
+  "exports": "./index.js",
+  "types": "./index.d.ts",
+  "browser": "./index.browser.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bitovi/hatchify.git"
+  },
+  "keywords": [
+    "isomorphic",
+    "webcrypto",
+    "crypto"
+  ],
+  "author": "Bitovi",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bitovi/hatchify/issues"
+  },
+  "homepage": "https://github.com/bitovi/hatchify#readme"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ESNext",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
     "declaration": true,
     "composite": true,
     "incremental": true,
@@ -22,9 +26,18 @@
     "useDefineForClassFields": true,
     "baseUrl": ".",
     "paths": {
-      "@hatchifyjs/core": ["./packages/core/dist"],
-      "@hatchifyjs/node": ["./packages/node/dist"]
+      "@hatchifyjs/core": [
+        "./packages/core/dist"
+      ],
+      "@hatchifyjs/crypto": [
+        "./packages/crypto"
+      ],
+      "@hatchifyjs/node": [
+        "./packages/node/dist"
+      ]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Take Hatchify usage of WebCrypto interface and move it into a separate package. This way we can ask bundlers to substitute a different implementation for the brower vs node.

Resolves Kleartrust's NextJS bundler issues.

This previously worked since it was a dynamic `require` for the `node:crypto` package that would never be run on the browser. We attempted to move it to a dynamic `import` since `require` is not valid in Node 20 compatible modules.