### PR TITLE
add rollup node-externals plugin 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15294,6 +15294,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/rollup-plugin-node-externals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-7.0.1.tgz",
+      "integrity": "sha512-NIGBhcuhyKn8slRsIt2mCHmxj5zRjXfkYjJ5FPjmg1Q3/rHvvMhOzj07kg0qVX/X6SEP2iubswIc0sL+CbXruA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 21 || ^20.6.0 || ^18.19.0"
+      },
+      "peerDependencies": {
+        "rollup": "^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
@@ -18755,6 +18767,7 @@
         "@types/react": "^18.0.28",
         "@vitejs/plugin-react": "^4.0.0",
         "@vitest/coverage-c8": "^0.32.2",
+        "rollup-plugin-node-externals": "^7.0.1",
         "vite": "^4.3.1",
         "vite-plugin-dts": "^2.3.0",
         "vitest": "^0.30.1"
@@ -18939,6 +18952,7 @@
         "@types/react": "^18.2.0",
         "@vitest/coverage-c8": "^0.32.2",
         "jsdom": "^21.1.1",
+        "rollup-plugin-node-externals": "^7.0.1",
         "vite": "^4.3.1",
         "vite-plugin-dts": "^2.3.0",
         "vitest": "^0.30.1"
@@ -18962,6 +18976,7 @@
         "@types/react": "^18.0.28",
         "@vitejs/plugin-react": "^4.0.0",
         "@vitest/coverage-c8": "^0.32.2",
+        "rollup-plugin-node-externals": "^7.0.1",
         "vite": "^4.3.1",
         "vite-plugin-dts": "^2.3.0",
         "vitest": "^0.30.1"
@@ -18971,30 +18986,6 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.10.0"
-      }
-    },
-    "packages/react/node_modules/@hatchifyjs/react-rest": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/react-rest/-/react-rest-0.1.20.tgz",
-      "integrity": "sha512-1XSG8Gl11MpnP6kqD/ijJ8NA5xmy7/OCqhx0hTalHpOean0lMwY0boxrzP8fUvU0cE3VmQ9erFNYaHuypa0h5Q==",
-      "dependencies": {
-        "@hatchifyjs/rest-client": "0.1.16"
-      },
-      "peerDependencies": {
-        "@hatchifyjs/core": "^0.3.x",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
-    "packages/react/node_modules/@hatchifyjs/rest-client": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@hatchifyjs/rest-client/-/rest-client-0.1.16.tgz",
-      "integrity": "sha512-5Oxf6u/Z4QnIiss0cnlF+g4xgjbJeF83dYKhQBPD9L1wwm6hN7m9KS1TMgHUGrW5qNFEWFgNJZwxwOdiDlBlEA==",
-      "dependencies": {
-        "lodash.isempty": "^4.4.0"
-      },
-      "peerDependencies": {
-        "@hatchifyjs/core": "^0.3.x"
       }
     },
     "packages/rest-client": {

--- a/packages/design-mui/package.json
+++ b/packages/design-mui/package.json
@@ -24,6 +24,7 @@
     "@types/react": "^18.0.28",
     "@vitejs/plugin-react": "^4.0.0",
     "@vitest/coverage-c8": "^0.32.2",
+    "rollup-plugin-node-externals": "^7.0.1",
     "vite": "^4.3.1",
     "vite-plugin-dts": "^2.3.0",
     "vitest": "^0.30.1"

--- a/packages/design-mui/vite.config.ts
+++ b/packages/design-mui/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
 import react from "@vitejs/plugin-react"
+import nodeExternals from "rollup-plugin-node-externals"
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,24 +11,13 @@ export default defineConfig({
       entry: "src/design-mui.ts",
       formats: ["es"],
     },
-    rollupOptions: {
-      external: [
-        "react",
-        "react-dom",
-        "@hatchifyjs/react-ui",
-        "@mui/icons-material",
-        "@mui/utils",
-        "react",
-        "react-dom",
-      ],
-    },
   },
   esbuild: {
     supported: {
       "top-level-await": true,
     },
   },
-  plugins: [dts(), react()],
+  plugins: [{ ...nodeExternals(), enforce: "pre" }, dts(), react()],
   test: {
     globals: true,
     environment: "jsdom",

--- a/packages/react-rest/package.json
+++ b/packages/react-rest/package.json
@@ -24,6 +24,7 @@
     "@types/react": "^18.2.0",
     "@vitest/coverage-c8": "^0.32.2",
     "jsdom": "^21.1.1",
+    "rollup-plugin-node-externals": "^7.0.1",
     "vite": "^4.3.1",
     "vite-plugin-dts": "^2.3.0",
     "vitest": "^0.30.1"

--- a/packages/react-rest/vite.config.ts
+++ b/packages/react-rest/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
+import nodeExternals from "rollup-plugin-node-externals"
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -8,14 +9,6 @@ export default defineConfig({
       entry: "src/react-rest.ts",
       formats: ["es", "cjs"],
     },
-    rollupOptions: {
-      external: [
-        "@hatchifyjs/core",
-        "@hatchifyjs/rest-client",
-        "react",
-        "react-dom",
-      ],
-    },
   },
-  plugins: [dts()],
+  plugins: [{ ...nodeExternals(), enforce: "pre" }, dts()],
 })

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^18.0.28",
     "@vitejs/plugin-react": "^4.0.0",
     "@vitest/coverage-c8": "^0.32.2",
+    "rollup-plugin-node-externals": "^7.0.1",
     "vite": "^4.3.1",
     "vite-plugin-dts": "^2.3.0",
     "vitest": "^0.30.1"

--- a/packages/react-ui/vite.config.ts
+++ b/packages/react-ui/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "vite"
 import dts from "vite-plugin-dts"
 import react from "@vitejs/plugin-react"
+import nodeExternals from "rollup-plugin-node-externals"
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,18 +11,8 @@ export default defineConfig({
       entry: "src/react-ui.ts",
       formats: ["es"],
     },
-    rollupOptions: {
-      external: [
-        "react",
-        "react-dom",
-        "react-router-dom",
-        "@hatchifyjs/core",
-        "@hatchifyjs/react-rest",
-        "@hatchifyjs/rest-client",
-      ],
-    },
   },
-  plugins: [dts(), react()],
+  plugins: [{ ...nodeExternals(), enforce: "pre" }, dts(), react()],
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
Implements correct import paths for node modules in the library-style output from Vite. Also prevents bundling any node dependencies since they'll be resolved by the final bundling done by the library consumer.
