### PR TITLE
(HATCH-478) implement react-ui tests

### DIFF
--- a/packages/react-ui/src/components/HatchifyDataGrid/HatchifyDataGrid.test.tsx
+++ b/packages/react-ui/src/components/HatchifyDataGrid/HatchifyDataGrid.test.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom"
+import { render } from "@testing-library/react"
+import { describe, it } from "vitest"
+import { assembler, integer } from "@hatchifyjs/core"
+import { default as HatchifyDataGrid } from "./HatchifyDataGrid.js"
+import hatchifyReactRest from "@hatchifyjs/react-rest"
+
+describe("components/HatchifyDataGrid", () => {
+  const partialSchemas = {
+    Todo: {
+      name: "Todo",
+      attributes: {
+        importance: integer(),
+      },
+    },
+  }
+
+  const finalSchemas = assembler(partialSchemas)
+
+  const fakeRestClient = hatchifyReactRest({
+    version: 0,
+    completeSchemaMap: partialSchemas,
+    findAll: () =>
+      Promise.resolve([
+        {
+          records: [
+            {
+              id: "1",
+              __schema: "Todo",
+              attributes: {
+                name: "foo",
+                created: "2021-01-01",
+                important: true,
+              },
+            },
+          ],
+          related: [],
+        },
+        {
+          unpaginatedCount: 1,
+        },
+      ]),
+    findOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    createOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    updateOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    deleteOne: () => Promise.resolve(),
+  })
+
+  it("Works", async () => {
+    render(
+      <HatchifyDataGrid
+        finalSchemas={finalSchemas}
+        partialSchemas={partialSchemas}
+        schemaName="Todo"
+        restClient={fakeRestClient}
+      />,
+    )
+  })
+})

--- a/packages/react-ui/src/components/HatchifyEmpty/HatchifyEmpty.test.tsx
+++ b/packages/react-ui/src/components/HatchifyEmpty/HatchifyEmpty.test.tsx
@@ -1,0 +1,10 @@
+import "@testing-library/jest-dom"
+import { render } from "@testing-library/react"
+import { describe, it } from "vitest"
+import { HatchifyEmpty } from "./HatchifyEmpty.js"
+
+describe("components/HatchifyEverything/components/HatchifyEmpty", () => {
+  it("Works", async () => {
+    render(<HatchifyEmpty> </HatchifyEmpty>)
+  })
+})

--- a/packages/react-ui/src/components/HatchifyEverything/HatchifyEverything.test.tsx
+++ b/packages/react-ui/src/components/HatchifyEverything/HatchifyEverything.test.tsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom"
+import { render } from "@testing-library/react"
+import { describe, it } from "vitest"
+import { assembler, integer } from "@hatchifyjs/core"
+import { HatchifyEverything } from "./HatchifyEverything.js"
+import hatchifyReactRest from "@hatchifyjs/react-rest"
+
+describe("components/HatchifyEverything/components/HatchifyEverything", () => {
+  const partialSchemas = {
+    Todo: {
+      name: "Todo",
+      attributes: {
+        importance: integer(),
+      },
+    },
+  }
+
+  const finalSchemas = assembler(partialSchemas)
+
+  const fakeRestClient = hatchifyReactRest({
+    version: 0,
+    completeSchemaMap: partialSchemas,
+    findAll: () =>
+      Promise.resolve([
+        {
+          records: [
+            {
+              id: "1",
+              __schema: "Todo",
+              attributes: {
+                name: "foo",
+                created: "2021-01-01",
+                important: true,
+              },
+            },
+          ],
+          related: [],
+        },
+        {
+          unpaginatedCount: 1,
+        },
+      ]),
+    findOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    createOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    updateOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    deleteOne: () => Promise.resolve(),
+  })
+  it("Works", async () => {
+    render(
+      <HatchifyEverything
+        partialSchemas={partialSchemas}
+        finalSchemas={finalSchemas}
+        restClient={fakeRestClient}
+      />,
+    )
+  })
+
+  it("Works with no schemas", async () => {
+    render(
+      <HatchifyEverything
+        partialSchemas={partialSchemas}
+        finalSchemas={{}}
+        restClient={fakeRestClient}
+      />,
+    )
+  })
+})

--- a/packages/react-ui/src/components/HatchifyEverything/HatchifyEverything.tsx
+++ b/packages/react-ui/src/components/HatchifyEverything/HatchifyEverything.tsx
@@ -26,7 +26,7 @@ export interface HatchifyEverythingProps<
   minimumLoadTime?: number
 }
 
-function HatchifyEverything<
+export function HatchifyEverything<
   const TSchemas extends Record<string, PartialSchema>,
 >({ finalSchemas, ...rest }: HatchifyEverythingProps<TSchemas>): JSX.Element {
   return (

--- a/packages/react-ui/src/components/HatchifyEverything/components/NoSchemas.test.tsx
+++ b/packages/react-ui/src/components/HatchifyEverything/components/NoSchemas.test.tsx
@@ -1,0 +1,10 @@
+import "@testing-library/jest-dom"
+import { render } from "@testing-library/react"
+import { describe, it } from "vitest"
+import { NoSchemas } from "./NoSchemas.js"
+
+describe("components/HatchifyEverything/components/NoSchemas", () => {
+  it("Works", async () => {
+    render(<NoSchemas />)
+  })
+})

--- a/packages/react-ui/src/components/HatchifyEverything/components/WithSchemas.test.tsx
+++ b/packages/react-ui/src/components/HatchifyEverything/components/WithSchemas.test.tsx
@@ -1,0 +1,57 @@
+import "@testing-library/jest-dom"
+import { render } from "@testing-library/react"
+import { describe, it } from "vitest"
+import { WithSchemas } from "./WithSchemas.js"
+import { assembler, integer } from "@hatchifyjs/core"
+import hatchifyReactRest from "@hatchifyjs/react-rest"
+
+describe("components/HatchifyEverything/components/WithSchemas", () => {
+  const partialSchemas = {
+    Todo: {
+      name: "Todo",
+      attributes: {
+        importance: integer(),
+      },
+    },
+  }
+
+  const finalSchemas = assembler(partialSchemas)
+
+  const fakeRestClient = hatchifyReactRest({
+    version: 0,
+    completeSchemaMap: partialSchemas,
+    findAll: () =>
+      Promise.resolve([
+        {
+          records: [
+            {
+              id: "1",
+              __schema: "Todo",
+              attributes: {
+                name: "foo",
+                created: "2021-01-01",
+                important: true,
+              },
+            },
+          ],
+          related: [],
+        },
+        {
+          unpaginatedCount: 1,
+        },
+      ]),
+    findOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    createOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    updateOne: () => Promise.resolve({ record: {} as any, related: [] }),
+    deleteOne: () => Promise.resolve(),
+  })
+  it("Works", async () => {
+    render(
+      <WithSchemas
+        partialSchemas={partialSchemas}
+        finalSchemas={finalSchemas}
+        restClient={fakeRestClient}
+      />,
+    )
+  })
+})

--- a/packages/react-ui/src/components/HatchifyPresentationProvider/DefaultDisplayComponents/DefaultDisplayComponents.test.tsx
+++ b/packages/react-ui/src/components/HatchifyPresentationProvider/DefaultDisplayComponents/DefaultDisplayComponents.test.tsx
@@ -1,0 +1,117 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import {
+  String,
+  StringList,
+  Number,
+  NumberList,
+  Boolean,
+  BooleanList,
+  Date,
+  DateList,
+  Relationship,
+  RelationshipList,
+} from "./DefaultDisplayComponents.js"
+
+describe("components/HatchifyPresentationProvider/DefaultDisplayComponents/", () => {
+  it("String works", async () => {
+    render(<String value={"Hello"} />)
+
+    expect(screen.getByText("Hello"))
+  })
+
+  it("StringList works", async () => {
+    render(<StringList values={["Hello, Goodbye"]} />)
+
+    expect(screen.getByText("Hello, Goodbye"))
+  })
+
+  it("Number works", async () => {
+    render(<Number value={1000} />)
+
+    expect(screen.getByText("1,000"))
+  })
+
+  it("NumberList works", async () => {
+    render(<NumberList values={[1, 1000, 2]} />)
+
+    expect(screen.getByText("1", { exact: false }))
+    expect(screen.getByText("1,000", { exact: false }))
+    expect(screen.getByText("2", { exact: false }))
+  })
+
+  it("Boolean works", async () => {
+    render(<Boolean value={true} />)
+
+    expect(screen.getByText("true"))
+  })
+
+  it("BooleanList works", async () => {
+    render(<BooleanList values={[true, true, false]} />)
+
+    expect(screen.getByText("true, true, false"))
+  })
+
+  describe("Date works", async () => {
+    it("dateOnly", async () => {
+      render(<Date dateOnly={true} value={"January 17, 2000"} />)
+      expect(screen.getByText("1/17/2000"))
+    })
+    it("full date", async () => {
+      render(<Date dateOnly={false} value={"January 17, 2000"} />)
+      expect(screen.getByText("1/17/2000, 12:00:00 AM"))
+    })
+
+    it("value is invalid", async () => {
+      render(<Date dateOnly={false} value={"Not a good date"} />)
+      expect(screen.queryByText("AM")).not.toBeInTheDocument()
+      expect(screen.queryByText("PM")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("DateList works", async () => {
+    it("dateOnly", async () => {
+      render(
+        <DateList
+          dateOnly={true}
+          values={["January 1, 2000", "February 1, 2000", "March 1, 2000"]}
+        />,
+      )
+      expect(screen.getByText("1/1/2000", { exact: false }))
+      expect(screen.getByText("2/1/2000", { exact: false }))
+      expect(screen.getByText("3/1/2000", { exact: false }))
+    })
+
+    it("full date", async () => {
+      render(
+        <DateList
+          dateOnly={false}
+          values={["January 1, 2000", "February 1, 2000", "March 1, 2000"]}
+        />,
+      )
+      expect(screen.getByText("1/1/2000, 12:00:00 AM", { exact: false }))
+      expect(screen.getByText("2/1/2000, 12:00:00 AM", { exact: false }))
+      expect(screen.getByText("3/1/2000, 12:00:00 AM", { exact: false }))
+    })
+  })
+
+  it("Relationship works", async () => {
+    render(
+      <Relationship value={{ id: "1", label: "label", something: true }} />,
+    )
+    expect(screen.getByText("label"))
+  })
+
+  it("RelationshipList works", async () => {
+    render(
+      <RelationshipList
+        values={[
+          { id: "1", label: "label", something: true },
+          { id: "2", label: "otherLabel", somethingNumber: 1 },
+        ]}
+      />,
+    )
+    expect(screen.getByText("label, otherLabel"))
+  })
+})

--- a/packages/react-ui/src/components/HatchifyPresentationProvider/DefaultFieldComponents/DefaultFieldComponents.test.tsx
+++ b/packages/react-ui/src/components/HatchifyPresentationProvider/DefaultFieldComponents/DefaultFieldComponents.test.tsx
@@ -1,0 +1,90 @@
+import "@testing-library/jest-dom"
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import {
+  String,
+  Number,
+  Boolean,
+  Date,
+  Relationship,
+} from "./DefaultFieldComponents.js"
+
+describe("components/HatchifyPresentationProvider/DefaultFieldComponents/", () => {
+  it("String works", async () => {
+    render(<String value={"Test"} label={"Test Label"} onUpdate={vi.fn()} />)
+    expect(screen.getByRole("textbox")).toHaveValue("Test")
+    expect(screen.getByText("Test Label", { exact: false }))
+  })
+
+  it("Number works", async () => {
+    render(<Number value={100} label={"Test Label"} onUpdate={vi.fn()} />)
+    expect(screen.getByRole("spinbutton")).toHaveValue(100)
+    expect(screen.getByText("Test Label", { exact: false }))
+  })
+
+  it("Boolean works", async () => {
+    render(<Boolean value={true} label={"Test Label"} onUpdate={vi.fn()} />)
+    expect(screen.getByRole("checkbox")).toBeChecked()
+    expect(screen.getByText("Test Label", { exact: false }))
+  })
+
+  it("Date works", async () => {
+    render(<Date value={"date"} label={"Test Label"} onUpdate={vi.fn()} />)
+    expect(screen.getByText("Test Label", { exact: false }))
+  })
+
+  it("Relationship works", async () => {
+    render(
+      <Relationship
+        values={["first"]}
+        label={"Test Label"}
+        options={[
+          { id: "1", label: "first" },
+          { id: "2", label: "second" },
+        ]}
+        hasMany={false}
+        onUpdate={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText("Test Label", { exact: false }))
+    expect(screen.getByLabelText("first"))
+    expect(screen.getByLabelText("second"))
+  })
+
+  //   it("Number works", async () => {
+  //     render(<Number value={1000} />)
+
+  //     expect(screen.getByText("1,000"))
+  //   })
+
+  //   it("Boolean works", async () => {
+  //     render(<Boolean value={true} />)
+
+  //     expect(screen.getByText("true"))
+  //   })
+
+  //   describe("Date works", async () => {
+  //     it("dateOnly", async () => {
+  //       render(<Date dateOnly={true} value={"January 17, 2000"} />)
+  //       expect(screen.getByText("1/17/2000"))
+  //     })
+  //     it("full date", async () => {
+  //       render(<Date dateOnly={false} value={"January 17, 2000"} />)
+  //       expect(screen.getByText("1/17/2000, 12:00:00 AM"))
+  //     })
+
+  //     it("value is invalid", async () => {
+  //       render(<Date dateOnly={false} value={"Not a good date"} />)
+  //       expect(screen.queryByText("AM")).not.toBeInTheDocument()
+  //       expect(screen.queryByText("PM")).not.toBeInTheDocument()
+  //     })
+  //   })
+
+  //   it("Relationship works", async () => {
+  //     render(
+  //       <Relationship value={{ id: "1", label: "label", something: true }} />,
+  //     )
+  //     expect(screen.getByText("label"))
+  //   })
+})

--- a/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.test.ts
+++ b/packages/react-ui/src/hooks/useCompoundComponents/helpers/getColumns.test.ts
@@ -115,4 +115,35 @@ describe("hooks/useCompoundComponents/helpers/getColumns", () => {
       },
     ])
   })
+
+  describe("overwrite", () => {
+    it("overwrite extra column works", () => {
+      const childArray = [
+        {
+          key: "Extra Details",
+          type: { name: "Column" },
+          props: { extra: "Extra Details" },
+        },
+      ] as JSX.Element[]
+
+      expect(
+        getColumns(
+          finalSchemas,
+          "Todo",
+          HatchifyPresentationDefaultValueComponents,
+          true,
+          childArray,
+        ),
+      ).toEqual([
+        {
+          headerOverride: false,
+          key: "extra-0",
+          label: "",
+          renderData: expect.any(Function),
+          renderHeader: expect.any(Function),
+          sortable: false,
+        },
+      ])
+    })
+  })
 })

--- a/packages/react-ui/src/hooks/useCompoundComponents/useCompoundComponents.test.tsx
+++ b/packages/react-ui/src/hooks/useCompoundComponents/useCompoundComponents.test.tsx
@@ -1,0 +1,36 @@
+import "@testing-library/jest-dom"
+import { renderHook } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { assembler, integer } from "@hatchifyjs/core"
+import useCompoundComponents from "./useCompoundComponents.js"
+
+describe("hooks/useCompoundComponents", () => {
+  const finalSchemas = assembler({
+    Todo: {
+      name: "Todo",
+      attributes: {
+        importance: integer(),
+      },
+    },
+  })
+
+  it("Works", async () => {
+    const { result } = renderHook(() =>
+      useCompoundComponents(finalSchemas, "Todo", false, null),
+    )
+
+    expect(result.current).toEqual({
+      Empty: expect.any(Function),
+      columns: [
+        {
+          headerOverride: false,
+          key: "importance",
+          label: "Importance",
+          renderData: expect.any(Function),
+          renderHeader: expect.any(Function),
+          sortable: true,
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
# Description

This brings the test coverage for the react-ui package up to 90%. 
Note, a good amount of the react-ui tests have been smoke tests since the restClient (or dataSource) and the hatchedReact components bring the elements together.

There are still tests that could use more coverage, but I've opted to prioritize other work rather than exceeding a sufficient coverage.

# Jira ticket links

https://bitovi.atlassian.net/browse/HATCH-478

# Test Plan

1. Navigate to the react-ui directory
2. ```npm run test:coverage```
3. Make sure there are no errors, but also review the code of course, some of the tests could be misguided.


# Definition of done

- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests?
- [ ] Is code secure? If applicable, add security notes to the description.
- [ ] Do all new TODO comments have Jira links with enough information?
- [ ] Were all changes published and deployed to [the grid](https://github.com/bitovi/hatchify-grid-demo)?
- [ ] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
