### PR TITLE
removing imports outside of @mui/material

### DIFF
--- a/packages/design-mui/src/components/MuiEverything/MuiEverything.tsx
+++ b/packages/design-mui/src/components/MuiEverything/MuiEverything.tsx
@@ -1,4 +1,4 @@
-import { Grid, Tabs, Tab, Typography } from "@mui/material";
+import { Grid, Tabs, Tab, Typography } from "@mui/material"
 import { HatchifyEmpty } from "@hatchifyjs/react-ui"
 import type { XEverythingProps } from "@hatchifyjs/react-ui"
 import type { PartialSchema } from "@hatchifyjs/core"

--- a/packages/design-mui/src/components/MuiEverything/MuiEverything.tsx
+++ b/packages/design-mui/src/components/MuiEverything/MuiEverything.tsx
@@ -1,7 +1,4 @@
-import Grid from "@mui/material/Grid/index.js"
-import Tabs from "@mui/material/Tabs/index.js"
-import Tab from "@mui/material/Tab/index.js"
-import Typography from "@mui/material/Typography/index.js"
+import {Grid, Tabs, Tab, Typography} from "@mui/material";
 import { HatchifyEmpty } from "@hatchifyjs/react-ui"
 import type { XEverythingProps } from "@hatchifyjs/react-ui"
 import type { PartialSchema } from "@hatchifyjs/core"

--- a/packages/design-mui/src/components/MuiEverything/MuiEverything.tsx
+++ b/packages/design-mui/src/components/MuiEverything/MuiEverything.tsx
@@ -1,4 +1,4 @@
-import {Grid, Tabs, Tab, Typography} from "@mui/material";
+import { Grid, Tabs, Tab, Typography } from "@mui/material";
 import { HatchifyEmpty } from "@hatchifyjs/react-ui"
 import type { XEverythingProps } from "@hatchifyjs/react-ui"
 import type { PartialSchema } from "@hatchifyjs/core"


### PR DESCRIPTION
There is a bug with importing a project from remix.

@mui/material would break on the following:

```
export { default } from './Grid';
```

Ultimately, everything seemed to work once these imports were removed:

```
import Grid from "@mui/material/Grid/index.js"
import Tabs from "@mui/material/Tabs/index.js"
import Tab from "@mui/material/Tab/index.js"
import Typography from "@mui/material/Typography/index.js"
```

I changed these to import named exports from `"@mui/material"`


# Jira ticket links

There is no jira ticket.  I'm working fast on the weekend.

# Test Plan

I'm going to publish and see if it fixes remix. We should add tests later. 

# Definition of done

- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests?
- [x] Is code secure? If applicable, add security notes to the description.
- [x] Do all new TODO comments have Jira links with enough information?
- [x] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
