### PR TITLE
fix: frontend typescript for date type

### DIFF
--- a/packages/rest-client/src/services/types/schema.ts
+++ b/packages/rest-client/src/services/types/schema.ts
@@ -77,7 +77,7 @@ type UnionToObject<
           ? EnumValues[any]
           : Type extends "String" | "string" | "STRING"
             ? string
-            : Type extends "Datetime" | "datetime" | "DATETIME"
+            : Type extends "Date" | "date" | "DATE"
               ? TMutate extends true
                 ? Date | string
                 : Date


### PR DESCRIPTION
- quick fix for typescript support on frontend:
  - `control.type` for `datetime()` and `dateonly()` returns `"Date"`
  - update frontend conversion of `control.type` -> Typescript type to check for `"Date"` rather than old `"Datetime"`