### PR TITLE
patch: force rest client publish, backwards compatible date type

### DIFF
--- a/packages/rest-client/src/services/types/schema.ts
+++ b/packages/rest-client/src/services/types/schema.ts
@@ -77,7 +77,13 @@ type UnionToObject<
           ? EnumValues[any]
           : Type extends "String" | "string" | "STRING"
             ? string
-            : Type extends "Date" | "date" | "DATE"
+            : Type extends
+                  | "Date"
+                  | "date"
+                  | "DATE"
+                  | "Datetime"
+                  | "datetime"
+                  | "DATETIME"
               ? TMutate extends true
                 ? Date | string
                 : Date


### PR DESCRIPTION
- convert `control.type` of `"Datetime"` to typescript Date in case using older version of core