### PR TITLE
Handling edge case bugs of create app command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ In just a few short steps we will set up a project containing a Hatchify fronten
 1. Ensure you’re using [node 18 and npm 9 or above](https://nodejs.org/en/download)
 
    ```bash
-   node -v
-   npm -v
+   echo Node: $(node -v) && echo npm: $(npm -v)
    ```
 
 2. Create a new project:

--- a/packages/create/src/constants.ts
+++ b/packages/create/src/constants.ts
@@ -2,13 +2,6 @@ import { blue, green, yellow } from "kolorist"
 import type { Database, Backend, Frontend } from "./types"
 
 export const BACKENDS: Record<string, Backend> = {
-  EXPRESS: {
-    name: "express",
-    display: "Express",
-    color: yellow,
-    dependencies: ["express", "@hatchifyjs/express"],
-    devDependencies: [],
-  },
   KOA: {
     name: "koa",
     display: "Koa",
@@ -16,22 +9,29 @@ export const BACKENDS: Record<string, Backend> = {
     dependencies: ["koa", "@hatchifyjs/koa"],
     devDependencies: ["@types/koa", "koa-connect"],
   },
+  EXPRESS: {
+    name: "express",
+    display: "Express",
+    color: yellow,
+    dependencies: ["express", "@hatchifyjs/express"],
+    devDependencies: [],
+  },
 }
 
 export const DATABASES: Record<string, Database> = {
-  POSTGRES: {
-    name: "postgres",
-    display: "Postgres",
-    color: yellow,
-    dependencies: ["pg", "dotenv"],
-    devDependencies: ["@types/pg"],
-  },
   SQLITE: {
     name: "sqlite",
     display: "SQLite",
     color: blue,
     dependencies: ["sqlite3"],
     devDependencies: [],
+  },
+  POSTGRES: {
+    name: "postgres",
+    display: "Postgres",
+    color: yellow,
+    dependencies: ["pg", "dotenv"],
+    devDependencies: ["@types/pg"],
   },
 }
 


### PR DESCRIPTION
Fixing three bugs:
1) If your project name has spaces, the command will fail. Now, packageName is used as the folder name. In the future, the project name could be used, but this would require a larger rewrite to support.
2) npm create vite@latest never ran on node version 20+. Now, it uses the exec command instead of spawn.sync(). Also, it now handles if the command fails and prints the error and exists.
3) Reading the template package.json sometimes asks for the file before it is fully written to the OS (race condition). Now, it has a new function, readFileWithRetries, to wait for the file to be ready. It also handles if a file is not found by printing an error and exiting.

Other Changes:
Updating CLI defaults to order match preferred, and making CLI version check a one-liner.

Tested on Node 20, 18.