### PR TITLE
hatch-632: option to limit notify subscriber from mutates

### DIFF
--- a/docs/react-jsonapi/README.md
+++ b/docs/react-jsonapi/README.md
@@ -160,7 +160,7 @@ const record = await hatchedReactRest.Todo.findOne({
 
 ### createOne
 
-`hatchedReactRest[SchemaName].createOne(data: Partial<RecordObject>) => Promise<RecordObject>`
+`hatchedReactRest[SchemaName].createOne(data: Partial<RecordObject>, mutateOptions?: MutateOptions) => Promise<RecordObject>`
 
 The `createOne` function creates a new record for the given schema, in this case Todo. Only the required attributes need to be passed in.
 
@@ -191,11 +191,25 @@ const createdRecord = await hatchedReactRest.Todo.createOne({
 })
 ```
 
+If you do not want to notify hooks and components of the `User` schema when a `Todo` is created, you can pass in the `notify` option.
+
+```ts
+const createdRecord = await hatchedReactRest.Todo.createOne(
+  {
+    name: "Learn Hatchify",
+    complete: false,
+    user: { id: UUID },
+  },
+  { notify: false },
+)
+```
+
 **Parameters**
 
-| Property | Type                                                | Details                                           |
-| -------- | --------------------------------------------------- | ------------------------------------------------- |
-| data     | <a href="#recordobject">`Partial<RecordObject>`</a> | An object containing the data for the new record. |
+| Property       | Type                                                      | Details                                                          |
+| -------------- | --------------------------------------------------------- | ---------------------------------------------------------------- |
+| data           | <a href="#recordobject">`Partial<RecordObject>`</a>       | An object containing the data for the new record.                |
+| mutateOptions? | <a href="#mutateoptions">`MutateOptions \| undefined`</a> | An object used to configure the behavior of a mutation function. |
 
 **Returns**
 
@@ -205,7 +219,7 @@ const createdRecord = await hatchedReactRest.Todo.createOne({
 
 ### updateOne
 
-`hatchedReactRest[SchemaName].updateOne(data: Partial<RecordObject>) => Promise<RecordObject>`
+`hatchedReactRest[SchemaName].updateOne(data: Partial<RecordObject>, mutateOptions?: MutateOptions) => Promise<RecordObject>`
 
 When using the `updateOne` function, the id must be passed in along with only the data that needs to be updated.
 
@@ -236,9 +250,10 @@ const updated = await hatchedReact.model.Todo.updateOne({
 
 **Parameters**
 
-| Property | Type                                                | Details                                                                                                 |
-| -------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| data     | <a href="#recordobject">`Partial<RecordObject>`</a> | An object containing the data for the updated record. The id is required to be passed into RecordObject |
+| Property       | Type                                                      | Details                                                                                                 |
+| -------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| data           | <a href="#recordobject">`Partial<RecordObject>`</a>       | An object containing the data for the updated record. The id is required to be passed into RecordObject |
+| mutateOptions? | <a href="#mutateoptions">`MutateOptions \| undefined`</a> | An object used to configure the behavior of a mutation function.                                        |
 
 **Returns**
 
@@ -248,7 +263,7 @@ const updated = await hatchedReact.model.Todo.updateOne({
 
 ### deleteOne
 
-`hatchedReactRest[SchemaName].deleteOne(id: string) => Promise<void>`
+`hatchedReactRest[SchemaName].deleteOne(id: string, mutateOptions?: MutateOptions) => Promise<void>`
 
 The `deleteOne` function deletes a record by its id.
 
@@ -258,9 +273,10 @@ await hatchedReactRest.Todo.deleteOne(UUID)
 
 **Parameters**
 
-| Property | Type     | Details                         |
-| -------- | -------- | ------------------------------- |
-| id       | `string` | The id of the record to delete. |
+| Property       | Type                                                      | Details                                                          |
+| -------------- | --------------------------------------------------------- | ---------------------------------------------------------------- |
+| id             | `string`                                                  | The id of the record to delete.                                  |
+| mutateOptions? | <a href="#mutateoptions">`MutateOptions \| undefined`</a> | An object used to configure the behavior of a mutation function. |
 
 **Returns**
 
@@ -360,7 +376,7 @@ An array with the following properties:
 
 ### useCreateOne
 
-`hatchedReactRest[SchemaName].useCreateOne() => [CreateFunction, RequestState, RecordObject?]`
+`hatchedReactRest[SchemaName].useCreateOne(mutateOptions?: MutateOptions) => [CreateFunction, RequestState, RecordObject?]`
 
 Here we use the `useCreateOne` hook to create a simple form for creating a new todo. We us the `createTodo` function when the form is submitted, the `RequestState` object to conditionally handle loading and error states, and we track the `created` object to console log the newly created record.
 
@@ -408,7 +424,7 @@ An array with the following properties:
 
 ### useUpdateOne
 
-`hatchedReactRest[SchemaName].useUpdateOne() => [UpdateFunction, { id: RequestState }, RecordObject?]`
+`hatchedReactRest[SchemaName].useUpdateOne(mutateOptions?: mutateOptions) => [UpdateFunction, { id: RequestState }, RecordObject?]`
 
 Here we use the `useUpdateOne` hook to create a simple edit form for updating a todo. We use the `updateTodo` function when the form is submitted, the `RequestState` object to conditionally handle loading and error states, and we track the `updated` object to console log the newly updated record.
 
@@ -455,7 +471,7 @@ An array with the following properties:
 
 ### useDeleteOne
 
-`hatchedReactRest[SchemaName].useDeleteOne() => [DeleteFunction, { id: RequestState }]`
+`hatchedReactRest[SchemaName].useDeleteOne(mutateOptions?: mutateOptions) => [DeleteFunction, { id: RequestState }]`
 
 Here we use the `useDeleteOne` hook to create alongside a list of todos. We use the `deleteTodo` function when the delete button is clicked, and the `RequestState` object to disable the delete button when the request is pending.
 
@@ -523,6 +539,26 @@ For passing in relationships through the `RecordObject`, see the example in the 
 | Property | Type  | Details                                  |
 | -------- | ----- | ---------------------------------------- |
 | ...      | `any` | Metadata, for example `unpaginatedCount` |
+
+### MutateOptions
+
+`MutateOptions` is an object used to configure the behavior of a mutation function.
+
+| Property | Type                                   | Details                                                                                            |
+| -------- | -------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| notify?  | `boolean \| SchemaName[] \| undefined` | Determines whether hooks and components should refetch data if a create, update, or delete happens |
+
+**notify**
+
+The `notify` property within the `MutateOptions` object is used to determine whether to refetch data for hooks (`useOne`, `useAll`, `useDataGridState`), and components (`DataGrid`).
+
+- By default, any mutation (create, update, or delete) will trigger a refetch of all active hooks and components for every schema.
+
+- If `notify` is omitted or set to `undefined`, all active hooks and components will refetch data.
+
+- If `notify` is set to `false`, only the schema that was mutated will refetch data. For exampple, `Todo.createOne({ ... })` will only refetch for hooks and components from the the `Todo` schema.
+
+- If `notify` is set to an array of schema names, only the specified schemas will refetch data as well as the mutated schema. For example, `Todo.createOne({ ... }, { notify: ["Person"] })` will only refetch for hooks and components from the `Todo` and `Person` schema.
 
 ### QueryList
 

--- a/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
+++ b/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
@@ -53,6 +53,7 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
           FlatCreateType<GetSchemaFromName<TSchemas, SchemaName>>,
           "__schema"
         >,
+        mutateOptions: MutateOptions<TSchemas>,
       ) => Promise<
         RecordType<TSchemas, GetSchemaFromName<TSchemas, SchemaName>>
       >
@@ -61,10 +62,14 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
           FlatUpdateType<GetSchemaFromName<TSchemas, SchemaName>>,
           "__schema"
         >,
+        mutateOptions: MutateOptions<TSchemas>,
       ) => Promise<
         RecordType<TSchemas, GetSchemaFromName<TSchemas, SchemaName>>
       >
-      deleteOne: (id: string) => Promise<void>
+      deleteOne: (
+        id: string,
+        mutateOptions: MutateOptions<TSchemas>,
+      ) => Promise<void>
       // hooks
       useAll: (
         query?: QueryList<GetSchemaFromName<TSchemas, SchemaName>>,
@@ -83,22 +88,28 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
         ),
         Meta,
       ]
-      useCreateOne: () => [
+      useCreateOne: <TMutateOptions extends MutateOptions<TSchemas>>(
+        mutateOptions: TMutateOptions,
+      ) => [
         (
           data: Omit<
             FlatCreateType<GetSchemaFromName<TSchemas, SchemaName>>,
             "__schema"
           >,
+          mutateOptions: TMutateOptions,
         ) => void,
         Meta,
         RecordType<TSchemas, GetSchemaFromName<TSchemas, SchemaName>>?,
       ]
-      useUpdateOne: () => [
+      useUpdateOne: <TMutateOptions extends MutateOptions<TSchemas>>(
+        mutateOptions: TMutateOptions,
+      ) => [
         (
           data: Omit<
             FlatUpdateType<GetSchemaFromName<TSchemas, SchemaName>>,
             "__schema"
           >,
+          mutateOptions: TMutateOptions,
         ) => void,
         ContextualMeta,
         (
@@ -107,7 +118,9 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
           | undefined
         ),
       ]
-      useDeleteOne: () => [(id: string) => void, ContextualMeta]
+      useDeleteOne: <TMutateOptions extends MutateOptions<TSchemas>>(
+        mutateOptions: TMutateOptions,
+      ) => [(id: string, mutateOptions: TMutateOptions) => void, ContextualMeta]
       // subscribes
       // subscribeToAll: (
       //   query: QueryList | undefined,
@@ -150,21 +163,21 @@ export const hatchifyReactRest = <
             typedSchemaName,
             query,
           ),
-        createOne: (data) =>
+        createOne: (data, mutateOptions) =>
           createOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
             typedSchemaName,
             data,
           ),
-        updateOne: (data) =>
+        updateOne: (data, mutateOptions) =>
           updateOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
             typedSchemaName,
             data,
           ),
-        deleteOne: (id: string) =>
+        deleteOne: (id, mutateOptions) =>
           deleteOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
@@ -188,19 +201,19 @@ export const hatchifyReactRest = <
             typedSchemaName,
             query,
           ),
-        useCreateOne: () =>
+        useCreateOne: (mutateOptions) =>
           useCreateOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
             typedSchemaName,
           ),
-        useUpdateOne: () =>
+        useUpdateOne: (mutateOptions) =>
           useUpdateOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
             typedSchemaName,
           ),
-        useDeleteOne: () =>
+        useDeleteOne: (mutateOptions) =>
           useDeleteOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,

--- a/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
+++ b/packages/react-rest/src/services/hatchifyReactRest/hatchifyReactRest.ts
@@ -13,6 +13,7 @@ import type {
   FlatCreateType,
   FlatUpdateType,
   ContextualMeta,
+  MutateOptions,
 } from "@hatchifyjs/rest-client"
 import {
   createStore,
@@ -53,7 +54,7 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
           FlatCreateType<GetSchemaFromName<TSchemas, SchemaName>>,
           "__schema"
         >,
-        mutateOptions: MutateOptions<TSchemas>,
+        mutateOptions?: MutateOptions<TSchemas>,
       ) => Promise<
         RecordType<TSchemas, GetSchemaFromName<TSchemas, SchemaName>>
       >
@@ -62,13 +63,13 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
           FlatUpdateType<GetSchemaFromName<TSchemas, SchemaName>>,
           "__schema"
         >,
-        mutateOptions: MutateOptions<TSchemas>,
+        mutateOptions?: MutateOptions<TSchemas>,
       ) => Promise<
         RecordType<TSchemas, GetSchemaFromName<TSchemas, SchemaName>>
       >
       deleteOne: (
         id: string,
-        mutateOptions: MutateOptions<TSchemas>,
+        mutateOptions?: MutateOptions<TSchemas>,
       ) => Promise<void>
       // hooks
       useAll: (
@@ -89,27 +90,25 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
         Meta,
       ]
       useCreateOne: <TMutateOptions extends MutateOptions<TSchemas>>(
-        mutateOptions: TMutateOptions,
+        mutateOptions?: TMutateOptions,
       ) => [
         (
           data: Omit<
             FlatCreateType<GetSchemaFromName<TSchemas, SchemaName>>,
             "__schema"
           >,
-          mutateOptions: TMutateOptions,
         ) => void,
         Meta,
         RecordType<TSchemas, GetSchemaFromName<TSchemas, SchemaName>>?,
       ]
       useUpdateOne: <TMutateOptions extends MutateOptions<TSchemas>>(
-        mutateOptions: TMutateOptions,
+        mutateOptions?: TMutateOptions,
       ) => [
         (
           data: Omit<
             FlatUpdateType<GetSchemaFromName<TSchemas, SchemaName>>,
             "__schema"
           >,
-          mutateOptions: TMutateOptions,
         ) => void,
         ContextualMeta,
         (
@@ -119,8 +118,8 @@ export type HatchifyReactRest<TSchemas extends Record<string, PartialSchema>> =
         ),
       ]
       useDeleteOne: <TMutateOptions extends MutateOptions<TSchemas>>(
-        mutateOptions: TMutateOptions,
-      ) => [(id: string, mutateOptions: TMutateOptions) => void, ContextualMeta]
+        mutateOptions?: TMutateOptions,
+      ) => [(id: string) => void, ContextualMeta]
       // subscribes
       // subscribeToAll: (
       //   query: QueryList | undefined,
@@ -169,6 +168,7 @@ export const hatchifyReactRest = <
             finalSchemas,
             typedSchemaName,
             data,
+            mutateOptions,
           ),
         updateOne: (data, mutateOptions) =>
           updateOne<TSchemas, TSchemaName>(
@@ -176,6 +176,7 @@ export const hatchifyReactRest = <
             finalSchemas,
             typedSchemaName,
             data,
+            mutateOptions,
           ),
         deleteOne: (id, mutateOptions) =>
           deleteOne<TSchemas, TSchemaName>(
@@ -183,6 +184,7 @@ export const hatchifyReactRest = <
             finalSchemas,
             typedSchemaName,
             id,
+            mutateOptions,
           ),
         // hooks
         useAll: (query, baseFilter, minimumLoadTime) =>
@@ -206,18 +208,21 @@ export const hatchifyReactRest = <
             restClient,
             finalSchemas,
             typedSchemaName,
+            mutateOptions,
           ),
         useUpdateOne: (mutateOptions) =>
           useUpdateOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
             typedSchemaName,
+            mutateOptions,
           ),
         useDeleteOne: (mutateOptions) =>
           useDeleteOne<TSchemas, TSchemaName>(
             restClient,
             finalSchemas,
             typedSchemaName,
+            mutateOptions,
           ),
       }
 
@@ -228,153 +233,3 @@ export const hatchifyReactRest = <
 
   return functions
 }
-
-// todo: leaving for testing, remove before merge to main
-// const partialTodo = {
-//   name: "Todo",
-//   attributes: {
-//     title: string(),
-//     reqTitle: string({ required: true }),
-//     age: integer({ required: true }),
-//     optAge: integer({ required: false }),
-//     important: boolean({ required: true }),
-//     optImportant: boolean(),
-//     created: datetime({ required: true }),
-//     optCreated: datetime(),
-//   },
-//   relationships: {
-//     user: belongsTo("User"),
-//     users: hasMany("User"),
-//   },
-// } satisfies PartialSchema
-
-// partialTodo.relationships.user.targetSchema
-// //                              ^?
-
-// const partialUser = {
-//   name: "User",
-//   attributes: {
-//     name: string({ required: true }),
-//     age: integer({ required: true }),
-//     employed: boolean(),
-//   },
-// } satisfies PartialSchema
-
-// const schemas = {
-//   Todo: partialTodo,
-//   User: partialUser,
-// }
-
-// const app = hatchifyReactRest({
-//   completeSchemaMap: schemas,
-// } as RestClient<typeof schemas, any>)
-
-// type Prettify<T> = {
-//   [K in keyof T]: T[K]
-// } & {}
-
-// app.Todo.createOne({
-//   attributes: { title: "hio", reqTitle: "", age: 0, important: false, created: "" },
-// })
-
-// app.Todo.findAll({
-//   include: ["user", "users"]
-// }).then(([records]) => {
-//   records[0].user
-// })
-
-// app.Todo.findOne("id").then((record) => {
-//   record?.user
-// })
-// app.User.findOne("id").then((record) => {
-//   record?.name
-//   record?.age
-//   record?.shouldError
-// })
-
-// const [one] = app.Todo.useOne("id")
-// one?.id
-// one?.optAge
-// one?.shouldError
-
-// app.Todo.findAll({}).then(([records]) => {
-//   records[0].id
-//   records[0].optAge
-//   records[0].shouldError
-// })
-
-// const [all] = app.Todo.useAll({})
-// all[0].id
-// all[0].optAge
-// all[0].shouldError
-
-// app.Todo.createOne({
-//   attributes: {
-//     reqTitle: "",
-//     age: 13,
-//     important: true,
-//     created: new Date(),
-//   },
-//   relationships: {
-//     user: {
-//       id: "1234",
-//     },
-//     users: [{ id: "1234" }],
-//   },
-// })
-// app.User.createOne({
-//   attributes: {
-//     name: "",
-//     age: 13,
-//     employed: true,
-//     shouldError: "",
-//   },
-// })
-
-// const [create] = app.Todo.useCreateOne()
-// create({
-//   attributes: {
-//     reqTitle: "",
-//     age: 13,
-//     important: true,
-//     created: new Date(),
-//     shouldError: "",
-//   },
-// })
-
-// app.Todo.updateOne({
-//   id: "1234",
-//   attributes: {
-//     reqTitle: "",
-//     age: 13,
-//     important: true,
-//     created: new Date(),
-//     // shouldError: '',
-//   },
-// })
-
-// const [update] = app.Todo.useUpdateOne()
-// update({
-//   id: "1234",
-//   attributes: {
-//     reqTitle: "",
-//     age: 13,
-//     important: true,
-//     created: new Date(),
-//     // user: {
-//     //   id: "1234"
-//     // }
-//     // shouldError: '',
-//   },
-//   relationships: {
-//     user: {
-//       id: "123",
-//     },
-//     users: [{
-//       id: "1234",
-//       id: "3434"
-//     }]
-//   }
-// })
-
-// app.Todo.deleteOne("1234")

--- a/packages/react-rest/src/services/useCreateOne/useCreateOne.ts
+++ b/packages/react-rest/src/services/useCreateOne/useCreateOne.ts
@@ -10,6 +10,7 @@ import type {
   MetaError,
   RestClient,
   FlatCreateType,
+  MutateOptions,
 } from "@hatchifyjs/rest-client"
 
 type CreateData<
@@ -33,6 +34,7 @@ export const useCreateOne = <
   dataSource: RestClient<TSchemas, TSchemaName>,
   allSchemas: FinalSchemas,
   schemaName: TSchemaName,
+  mutateOptions?: MutateOptions<TSchemas>,
 ): [
   (data: CreateData<TSchemas, TSchemaName>) => void,
   Meta,
@@ -46,7 +48,13 @@ export const useCreateOne = <
   const create = useCallback(
     (data: CreateData<TSchemas, TSchemaName>) => {
       setLoading(true)
-      createOne<TSchemas, TSchemaName>(dataSource, allSchemas, schemaName, data)
+      createOne<TSchemas, TSchemaName>(
+        dataSource,
+        allSchemas,
+        schemaName,
+        data,
+        mutateOptions,
+      )
         .then((data) => {
           setError(undefined)
           setData(data)
@@ -59,7 +67,7 @@ export const useCreateOne = <
         })
         .finally(() => setLoading(false))
     },
-    [dataSource, allSchemas, schemaName],
+    [dataSource, allSchemas, schemaName, mutateOptions],
   )
 
   const meta = useMemo(

--- a/packages/react-rest/src/services/useDeleteOne/useDeleteOne.ts
+++ b/packages/react-rest/src/services/useDeleteOne/useDeleteOne.ts
@@ -6,6 +6,7 @@ import type {
   FinalSchemas,
   GetSchemaNames,
   MetaError,
+  MutateOptions,
   RestClient,
 } from "@hatchifyjs/rest-client"
 
@@ -19,12 +20,19 @@ export const useDeleteOne = <
   dataSource: RestClient<TSchemas, TSchemaName>,
   allSchemas: FinalSchemas,
   schemaName: TSchemaName,
+  mutateOptions?: MutateOptions<TSchemas>,
 ): [(id: string) => void, ContextualMeta] => {
   const [meta, setMeta] = useState<ContextualMeta>(() => ({}))
 
   const remove = useCallback(
     (id: string) => {
-      deleteOne<TSchemas, TSchemaName>(dataSource, allSchemas, schemaName, id)
+      deleteOne<TSchemas, TSchemaName>(
+        dataSource,
+        allSchemas,
+        schemaName,
+        id,
+        mutateOptions,
+      )
         .then(() =>
           setMeta((prev: ContextualMeta) => {
             return {
@@ -53,7 +61,7 @@ export const useDeleteOne = <
           }),
         )
     },
-    [dataSource, allSchemas, schemaName],
+    [dataSource, allSchemas, schemaName, mutateOptions],
   )
 
   return [remove, meta]

--- a/packages/react-rest/src/services/useUpdateOne/useUpdateOne.ts
+++ b/packages/react-rest/src/services/useUpdateOne/useUpdateOne.ts
@@ -10,6 +10,7 @@ import type {
   MetaError,
   RestClient,
   ContextualMeta,
+  MutateOptions,
 } from "@hatchifyjs/rest-client"
 
 type UpdateData<
@@ -33,6 +34,7 @@ export const useUpdateOne = <
   dataSource: RestClient<TSchemas, TSchemaName>,
   allSchemas: FinalSchemas,
   schemaName: TSchemaName,
+  mutateOptions?: MutateOptions<TSchemas>,
 ): [
   (data: UpdateData<TSchemas, TSchemaName>) => void,
   ContextualMeta,
@@ -44,7 +46,13 @@ export const useUpdateOne = <
 
   const update = useCallback(
     (data: UpdateData<TSchemas, TSchemaName>) => {
-      updateOne<TSchemas, TSchemaName>(dataSource, allSchemas, schemaName, data)
+      updateOne<TSchemas, TSchemaName>(
+        dataSource,
+        allSchemas,
+        schemaName,
+        data,
+        mutateOptions,
+      )
         .then((data) => {
           setMeta((prev) => ({
             ...prev,
@@ -72,7 +80,7 @@ export const useUpdateOne = <
           }),
         )
     },
-    [dataSource, allSchemas, schemaName],
+    [dataSource, allSchemas, schemaName, mutateOptions],
   )
 
   return [update, meta, data]

--- a/packages/rest-client/src/rest-client.ts
+++ b/packages/rest-client/src/rest-client.ts
@@ -14,6 +14,7 @@ export type {
   Include,
   Meta,
   MetaError,
+  MutateOptions,
   MutateRelationship,
   MutateRelationships,
   PaginationObject,

--- a/packages/rest-client/src/services/promise/createOne/createOne.ts
+++ b/packages/rest-client/src/services/promise/createOne/createOne.ts
@@ -63,7 +63,7 @@ export const createOne = async <
   } else if (notify === false) {
     notifySubscribers(schemaName) // notify only subscribers of this schema
   } else {
-    notifySubscribers(notify) // notify only subscribers of the specified schemas
+    notifySubscribers([schemaName, ...notify]) // notify only subscribers of the specified schemas
   }
 
   // todo: HATCH-417; return from `flattenResourcesIntoRecords` needs to be `RecordType`

--- a/packages/rest-client/src/services/promise/createOne/createOne.ts
+++ b/packages/rest-client/src/services/promise/createOne/createOne.ts
@@ -7,6 +7,7 @@ import type {
   GetSchemaFromName,
   RecordType,
   FlatCreateType,
+  MutateOptions,
 } from "../../types/index.js"
 import { notifySubscribers } from "../../store/index.js"
 import {
@@ -32,6 +33,7 @@ export const createOne = async <
     FlatCreateType<GetSchemaFromName<TSchemas, TSchemaName>>,
     "__schema"
   >,
+  { notify }: MutateOptions<TSchemas>,
 ): Promise<RecordType<TSchemas, GetSchemaFromName<TSchemas, TSchemaName>>> => {
   if (!schemaNameIsString(schemaName)) {
     throw new SchemaNameNotStringError(schemaName)
@@ -56,7 +58,13 @@ export const createOne = async <
     relationships: relationships, // does not need to be serialized! only ids, does not contain attribute values
   })
 
-  notifySubscribers()
+  if (notify == null || notify === true) {
+    notifySubscribers() // notify all
+  } else if (notify === false) {
+    notifySubscribers(schemaName) // notify only subscribers of this schema
+  } else {
+    notifySubscribers(notify) // notify only subscribers of the specified schemas
+  }
 
   // todo: HATCH-417; return from `flattenResourcesIntoRecords` needs to be `RecordType`
   // @ts-expect-error

--- a/packages/rest-client/src/services/promise/createOne/createOne.ts
+++ b/packages/rest-client/src/services/promise/createOne/createOne.ts
@@ -33,7 +33,7 @@ export const createOne = async <
     FlatCreateType<GetSchemaFromName<TSchemas, TSchemaName>>,
     "__schema"
   >,
-  { notify }: MutateOptions<TSchemas>,
+  mutateOptions?: MutateOptions<TSchemas>,
 ): Promise<RecordType<TSchemas, GetSchemaFromName<TSchemas, TSchemaName>>> => {
   if (!schemaNameIsString(schemaName)) {
     throw new SchemaNameNotStringError(schemaName)
@@ -58,13 +58,7 @@ export const createOne = async <
     relationships: relationships, // does not need to be serialized! only ids, does not contain attribute values
   })
 
-  if (notify == null || notify === true) {
-    notifySubscribers() // notify all
-  } else if (notify === false) {
-    notifySubscribers(schemaName) // notify only subscribers of this schema
-  } else {
-    notifySubscribers([schemaName, ...notify]) // notify only subscribers of the specified schemas
-  }
+  notifySubscribers(schemaName, mutateOptions?.notify)
 
   // todo: HATCH-417; return from `flattenResourcesIntoRecords` needs to be `RecordType`
   // @ts-expect-error

--- a/packages/rest-client/src/services/promise/deleteOne/deleteOne.ts
+++ b/packages/rest-client/src/services/promise/deleteOne/deleteOne.ts
@@ -2,6 +2,7 @@ import type { PartialSchema } from "@hatchifyjs/core"
 import type {
   FinalSchemas,
   GetSchemaNames,
+  MutateOptions,
   RestClient,
 } from "../../types/index.js"
 import { notifySubscribers } from "../../store/index.js"
@@ -21,6 +22,7 @@ export const deleteOne = async <
   allSchemas: FinalSchemas,
   schemaName: TSchemaName,
   id: string,
+  mutateOptions?: MutateOptions<TSchemas>,
 ): Promise<void> => {
   if (!schemaNameIsString(schemaName)) {
     throw new SchemaNameNotStringError(schemaName)
@@ -28,7 +30,7 @@ export const deleteOne = async <
 
   await dataSource.deleteOne(allSchemas, schemaName, id)
 
-  notifySubscribers()
+  notifySubscribers(schemaName, mutateOptions?.notify)
 
   return
 }

--- a/packages/rest-client/src/services/promise/updateOne/updateOne.ts
+++ b/packages/rest-client/src/services/promise/updateOne/updateOne.ts
@@ -8,6 +8,7 @@ import type {
   GetSchemaFromName,
   RecordType,
   FlatUpdateType,
+  MutateOptions,
 } from "../../types/index.js"
 import { notifySubscribers } from "../../store/index.js"
 import {
@@ -33,6 +34,7 @@ export const updateOne = async <
     FlatUpdateType<GetSchemaFromName<TSchemas, TSchemaName>>,
     "__schema"
   >,
+  mutateOptions?: MutateOptions<TSchemas>,
 ): Promise<RecordType<TSchemas, GetSchemaFromName<TSchemas, TSchemaName>>> => {
   if (!schemaNameIsString(schemaName)) {
     throw new SchemaNameNotStringError(schemaName)
@@ -60,7 +62,7 @@ export const updateOne = async <
     relationships: relationships || undefined, // does not need to be serialized! only ids, does not contain attribute values
   })
 
-  notifySubscribers()
+  notifySubscribers(schemaName, mutateOptions?.notify)
 
   // todo: HATCH-417; return from `flattenResourcesIntoRecords` needs to be `RecordType`
   // @ts-expect-error

--- a/packages/rest-client/src/services/store/store.ts
+++ b/packages/rest-client/src/services/store/store.ts
@@ -1,5 +1,7 @@
+import type { PartialSchema } from "packages/core/dist/core.js"
 import type {
   FinalSchemas,
+  MutateOptions,
   Record,
   Resource,
   Subscription,
@@ -84,21 +86,34 @@ export function insert(
   }
 }
 
-/**
- * Notifies subscribers whenever a resource is created, updated, or deleted.
- */
-export function notifySubscribers(schemaName?: string): void {
-  // if no schemaName is provided, notify all subscribers for all schemas
-  if (!schemaName) {
-    for (const schemaName in store) {
-      notifySubscribers(schemaName)
-    }
-
-    return
-  }
-
+export function notifySchema(schemaName: string): void {
   for (const subscriber of store[schemaName].subscribers) {
-    subscriber([]) // todo, future: should notify with can-query-logic results
+    subscriber([])
+  }
+}
+
+export function notifySubscribers<
+  TSchemas extends globalThis.Record<string, PartialSchema>,
+  TSchemaName extends keyof TSchemas,
+>(
+  schemaName: TSchemaName | string,
+  notify?: MutateOptions<TSchemas>["notify"],
+): void {
+  if (notify == null || notify === true) {
+    // if notify omitted or true, notify subscribers for all schemas
+    for (const schemaName in store) {
+      notifySchema(schemaName)
+    }
+  } else if (notify === false) {
+    // notify subscribers for only the mutated schema
+    notifySchema(schemaName as string)
+  } else {
+    // notify specified schemas as well as the mutated schema
+    const toNotify = new Set([schemaName, ...notify] as string[])
+
+    toNotify.forEach((schemaName) => {
+      notifySchema(schemaName)
+    })
   }
 }
 

--- a/packages/rest-client/src/services/types/rest-client.ts
+++ b/packages/rest-client/src/services/types/rest-client.ts
@@ -13,6 +13,10 @@ import type {
   WithRequiredProperty,
 } from "./index.js"
 
+export type MutateOptions<TSchemas, TSchemaName> = {
+  notify?: boolean | Omit<keyof TSchemas, TSchemaName>
+}
+
 export type RestClientSchema = PartialSchema & {
   type?: string
   endpoint?: string

--- a/packages/rest-client/src/services/types/rest-client.ts
+++ b/packages/rest-client/src/services/types/rest-client.ts
@@ -13,8 +13,8 @@ import type {
   WithRequiredProperty,
 } from "./index.js"
 
-export type MutateOptions<TSchemas, TSchemaName> = {
-  notify?: boolean | Omit<keyof TSchemas, TSchemaName>
+export type MutateOptions<TSchemas extends Record<string, PartialSchema>> = {
+  notify?: boolean | Array<keyof TSchemas>
 }
 
 export type RestClientSchema = PartialSchema & {

--- a/packages/rest-client/src/services/types/schema.ts
+++ b/packages/rest-client/src/services/types/schema.ts
@@ -1,12 +1,4 @@
 import type { FinalSchema, PartialSchema } from "@hatchifyjs/core"
-// import {
-//   belongsTo,
-//   boolean,
-//   hasMany,
-//   integer,
-//   string,
-//   enumerate,
-// } from "@hatchifyjs/core"
 
 export type FinalSchemas = Record<string, FinalSchema>
 


### PR DESCRIPTION
hatch-632: option to limit data refetches on mutation

# Description
- whenever any mutation (create, update, delete) then every useAll, useOne, useDataGridState, and DataGrid will refetch data (and go into loading state) - even if the schemas are unrelated
- provide an optional flag to limit which hooks/components will refetch data for a mutate
  - if schema X is mutated, then hooks/components will *always* refetch, regardless of notify flag
  - if notify is false, and schema X is mutated, only schema X will refetch data
  - if notify is undefined/options are omitted and schema X is mutated, all schemas will refetch data
  - if notify is an array of schema [Y, Z] and schema X is mutated, schema X,Y,Z will refetch data

# Jira ticket links
https://bitovi.atlassian.net/browse/HATCH-632

# Test Plan
- manually tested

# Definition of done
- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests?
- [ ] Is code secure? If applicable, add security notes to the description.
- [ ] Do all new TODO comments have Jira links with enough information?
- [ ] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
