### PR TITLE
hatch-512: move alwaysSorted option to DataGrid/state level

### DIFF
--- a/packages/design-mui/src/components/MuiList/components/MuiHeaders/MuiHeaders.tsx
+++ b/packages/design-mui/src/components/MuiList/components/MuiHeaders/MuiHeaders.tsx
@@ -14,7 +14,7 @@ export const MuiHeaders: React.FC<
   XDataGridProps & { columns: HatchifyColumn[] }
 > = ({ selected, setSelected, sort, setSort, data, columns, meta }) => {
   const selectable = selected !== undefined && setSelected !== undefined
-  const { direction, sortBy, alwaysSorted } = sort
+  const { direction, sortBy } = sort
 
   return (
     <TableHead>
@@ -43,7 +43,6 @@ export const MuiHeaders: React.FC<
             sortDirection={column.key === sortBy ? direction : false}
           >
             <Sortable
-              alwaysSorted={alwaysSorted}
               direction={direction}
               isPending={meta.isPending}
               columnKey={column.key}
@@ -57,7 +56,6 @@ export const MuiHeaders: React.FC<
                   key: column.key,
                   label: column.label,
                 },
-                alwaysSorted,
                 meta,
                 sortBy,
                 direction,

--- a/packages/design-mui/src/components/MuiList/components/MuiHeaders/components/Sort.tsx
+++ b/packages/design-mui/src/components/MuiList/components/MuiHeaders/components/Sort.tsx
@@ -4,23 +4,15 @@ import { Box, TableSortLabel } from "@mui/material"
 import { visuallyHidden } from "@mui/utils"
 
 export const Sort: React.FC<
-  Pick<HeaderProps, "direction" | "setSort" | "sortBy" | "alwaysSorted"> & {
+  Pick<HeaderProps, "direction" | "setSort" | "sortBy"> & {
     children: React.ReactNode
     isPending: Meta["isPending"]
     columnKey: HatchifyColumn["key"]
   }
-> = ({
-  alwaysSorted,
-  children,
-  columnKey,
-  direction,
-  isPending,
-  setSort,
-  sortBy,
-}) => (
+> = ({ children, columnKey, direction, isPending, setSort, sortBy }) => (
   <TableSortLabel
     disabled={isPending}
-    active={alwaysSorted || columnKey === sortBy}
+    active={columnKey === sortBy}
     direction={sortBy === sortBy ? direction : "asc"}
     onClick={() => setSort(columnKey)}
     sx={{

--- a/packages/design-mui/src/components/MuiList/components/MuiHeaders/components/Sortable.tsx
+++ b/packages/design-mui/src/components/MuiList/components/MuiHeaders/components/Sortable.tsx
@@ -3,14 +3,13 @@ import { Sort } from "./Sort.js"
 import type { HatchifyColumn, HeaderProps } from "@hatchifyjs/react-ui"
 
 export const Sortable: React.FC<
-  Pick<HeaderProps, "direction" | "setSort" | "sortBy" | "alwaysSorted"> & {
+  Pick<HeaderProps, "direction" | "setSort" | "sortBy"> & {
     children: React.ReactNode
     isPending: Meta["isPending"]
     columnKey: HatchifyColumn["key"]
     sortable: boolean
   }
 > = ({
-  alwaysSorted,
   children,
   columnKey,
   direction,
@@ -21,7 +20,6 @@ export const Sortable: React.FC<
 }) =>
   sortable ? (
     <Sort
-      alwaysSorted={alwaysSorted}
       direction={direction}
       isPending={isPending}
       columnKey={columnKey}

--- a/packages/react-ui/src/components/HatchifyDataGrid/HatchifyDataGrid.tsx
+++ b/packages/react-ui/src/components/HatchifyDataGrid/HatchifyDataGrid.tsx
@@ -33,6 +33,7 @@ export interface HatchifyDataGridProps<
   overwrite?: boolean
   minimumLoadTime?: number
   fitParent?: boolean
+  alwaysSorted?: boolean
 }
 
 function HatchifyDataGrid<
@@ -52,6 +53,7 @@ function HatchifyDataGrid<
   overwrite,
   minimumLoadTime,
   fitParent,
+  alwaysSorted,
 }: HatchifyDataGridProps<TSchemas, TSchemaName>): JSX.Element {
   const { DataGrid } = useHatchifyPresentation()
   const defaultInclude = useMemo(
@@ -63,6 +65,7 @@ function HatchifyDataGrid<
     [finalSchemas, schemaName],
   )
 
+  // console.log('HatchifyDataGrid.always')
   const dataGridState = useDataGridState(
     finalSchemas,
     partialSchemas,
@@ -76,6 +79,7 @@ function HatchifyDataGrid<
       defaultSort,
       baseFilter,
       minimumLoadTime,
+      alwaysSorted,
     },
   )
 

--- a/packages/react-ui/src/hatchifyReact/hatchifyReact.tsx
+++ b/packages/react-ui/src/hatchifyReact/hatchifyReact.tsx
@@ -111,6 +111,7 @@ export type HatchifyApp<TSchemas extends Record<string, PartialSchema>> = {
         include,
         defaultPage,
         defaultSort,
+        alwaysSorted,
         baseFilter,
         minimumLoadTime,
       }?: {
@@ -126,6 +127,7 @@ export type HatchifyApp<TSchemas extends Record<string, PartialSchema>> = {
         include?: Include<GetSchemaFromName<TSchemas, SchemaName>>
         defaultPage?: PaginationObject
         defaultSort?: SortObject
+        alwaysSorted?: boolean
         baseFilter?: Filters
         minimumLoadTime?: number
       }) => DataGridState<TSchemas, SchemaName>
@@ -206,6 +208,7 @@ export function hatchifyReact<
           include,
           defaultPage,
           defaultSort,
+          alwaysSorted,
           baseFilter,
           minimumLoadTime,
         } = {}) =>
@@ -221,6 +224,7 @@ export function hatchifyReact<
               include,
               defaultPage,
               defaultSort,
+              alwaysSorted,
               baseFilter,
               minimumLoadTime,
             },

--- a/packages/react-ui/src/hooks/useDataGridState.ts
+++ b/packages/react-ui/src/hooks/useDataGridState.ts
@@ -61,6 +61,7 @@ export default function useDataGridState<
     include,
     defaultPage,
     defaultSort,
+    alwaysSorted,
     baseFilter,
     minimumLoadTime,
   }: {
@@ -70,6 +71,7 @@ export default function useDataGridState<
     include?: Include<GetSchemaFromName<TSchemas, TSchemaName>>
     defaultPage?: PaginationObject
     defaultSort?: SortObject
+    alwaysSorted?: boolean
     baseFilter?: Filters
     minimumLoadTime?: number
   } = {},
@@ -81,7 +83,7 @@ export default function useDataGridState<
   }
 
   const { page, setPage } = usePage(defaultPage)
-  const { sort, sortQueryString, setSort } = useSort(defaultSort)
+  const { sort, sortQueryString, setSort } = useSort(defaultSort, alwaysSorted)
   const { filter, setFilter } = useFilter()
   const { selected, setSelected } = useSelected(
     defaultSelected,

--- a/packages/react-ui/src/hooks/useSort.test.ts
+++ b/packages/react-ui/src/hooks/useSort.test.ts
@@ -8,7 +8,6 @@ describe("useSort", () => {
 
     // initial state
     expect(result.current.sort).toEqual({
-      alwaysSorted: false,
       direction: undefined,
       sortBy: undefined,
     })
@@ -20,7 +19,6 @@ describe("useSort", () => {
 
     // after first click, undefined -> asc
     expect(result.current.sort).toEqual({
-      alwaysSorted: false,
       direction: "asc",
       sortBy: "name",
     })
@@ -32,7 +30,6 @@ describe("useSort", () => {
 
     // after second click, asc -> desc
     expect(result.current.sort).toEqual({
-      alwaysSorted: false,
       direction: "desc",
       sortBy: "name",
     })
@@ -44,7 +41,6 @@ describe("useSort", () => {
 
     // after third click, desc -> undefined
     expect(result.current.sort).toEqual({
-      alwaysSorted: false,
       direction: undefined,
       sortBy: undefined,
     })
@@ -56,7 +52,6 @@ describe("useSort", () => {
 
     // after fourth click, undefined -> asc
     expect(result.current.sort).toEqual({
-      alwaysSorted: false,
       direction: "asc",
       sortBy: "name",
     })
@@ -68,7 +63,6 @@ describe("useSort", () => {
 
     // after new column click, asc
     expect(result.current.sort).toEqual({
-      alwaysSorted: false,
       direction: "asc",
       sortBy: "date",
     })
@@ -77,14 +71,13 @@ describe("useSort", () => {
 
   it("works when alwaysSorted is true", async () => {
     const { result } = renderHook(() =>
-      useSort({ direction: undefined, sortBy: undefined, alwaysSorted: true }),
+      useSort({ direction: undefined, sortBy: undefined }, true),
     )
 
     // initial state
     expect(result.current.sort).toEqual({
       direction: undefined,
       sortBy: undefined,
-      alwaysSorted: true,
     })
     expect(result.current.sortQueryString).toEqual("")
 
@@ -96,7 +89,6 @@ describe("useSort", () => {
     expect(result.current.sort).toEqual({
       direction: "asc",
       sortBy: "name",
-      alwaysSorted: true,
     })
     expect(result.current.sortQueryString).toEqual("name")
 
@@ -108,7 +100,6 @@ describe("useSort", () => {
     expect(result.current.sort).toEqual({
       direction: "desc",
       sortBy: "name",
-      alwaysSorted: true,
     })
     expect(result.current.sortQueryString).toEqual("-name")
 
@@ -120,7 +111,6 @@ describe("useSort", () => {
     expect(result.current.sort).toEqual({
       direction: "asc",
       sortBy: "name",
-      alwaysSorted: true,
     })
     expect(result.current.sortQueryString).toEqual("name")
 
@@ -132,7 +122,6 @@ describe("useSort", () => {
     expect(result.current.sort).toEqual({
       direction: "desc",
       sortBy: "name",
-      alwaysSorted: true,
     })
     expect(result.current.sortQueryString).toEqual("-name")
 
@@ -144,7 +133,6 @@ describe("useSort", () => {
     expect(result.current.sort).toEqual({
       direction: "asc",
       sortBy: "date",
-      alwaysSorted: true,
     })
     expect(result.current.sortQueryString).toEqual("date")
   })

--- a/packages/react-ui/src/hooks/useSort.ts
+++ b/packages/react-ui/src/hooks/useSort.ts
@@ -3,10 +3,10 @@ import type { HatchifyDataGridSort, SortObject } from "../presentation/index.js"
 
 export default function useSort(
   defaultSort?: SortObject,
+  alwaysSorted?: boolean,
 ): HatchifyDataGridSort {
   const [sort, setSort] = useState<SortObject>(
     defaultSort ?? {
-      alwaysSorted: false,
       direction: undefined,
       sortBy: undefined,
     },
@@ -19,15 +19,15 @@ export default function useSort(
     return `${sort.direction === "desc" ? "-" : ""}${sort.sortBy}`
   }, [sort.sortBy, sort.direction])
 
-  const updateSort = (sortBy: string, alwaysSorted = sort.alwaysSorted) => {
+  const updateSort = (sortBy: string) => {
     if (alwaysSorted && sort.direction === "desc") {
-      setSort({ sortBy, direction: "asc", alwaysSorted })
+      setSort({ sortBy, direction: "asc" })
     } else if (sort.sortBy === undefined || sort.sortBy !== sortBy) {
-      setSort({ sortBy, direction: "asc", alwaysSorted })
+      setSort({ sortBy, direction: "asc" })
     } else if (sort.direction === "asc") {
-      setSort({ sortBy, direction: "desc", alwaysSorted })
+      setSort({ sortBy, direction: "desc" })
     } else {
-      setSort({ sortBy: undefined, direction: undefined, alwaysSorted })
+      setSort({ sortBy: undefined, direction: undefined })
     }
   }
 

--- a/packages/react-ui/src/presentation/interfaces.ts
+++ b/packages/react-ui/src/presentation/interfaces.ts
@@ -14,7 +14,6 @@ export interface XProviderProps {
 export interface SortObject {
   direction: "asc" | "desc" | undefined
   sortBy: string | undefined
-  alwaysSorted?: boolean
 }
 
 export interface PageCountObject {
@@ -57,6 +56,8 @@ export interface XDataGridProps<
   minimumLoadTime?: number
   listWrapperId?: string
   fitParent?: boolean
+  alwaysSorted?: boolean
+  initialSort?: SortObject
 }
 
 export interface XEverythingProps<
@@ -114,5 +115,4 @@ interface HeaderPropsCommon {
   meta: Meta
   setSort: HatchifyDataGridSort["setSort"]
   sortBy: SortObject["sortBy"]
-  alwaysSorted: SortObject["alwaysSorted"]
 }


### PR DESCRIPTION
# Description
- removed `alwaysSorted` prop from column components
- `alwaysSorted` can now be passed into a `DataGrid` component or into a `useDataGridState` (when using the eject/spread pattern)
- ticket mentions `initialSort`; we already have this functionality but the prop is called `defaultSort`. left it as is because we have some other `default_` props; if we want to rename we should do all of them in a separate ticket

# Jira ticket links
- https://bitovi.atlassian.net/browse/HATCH-512

# Test Plan
- run e2e app app with:
```tsx
const TodoDataGrid = hatchedReact.components.Todo.DataGrid
const { List, Pagination, Filters } = hatchedReact.components.Todo

const App: React.FC = () => {
  const state = hatchedReact.state.Todo.useDataGridState({
    include: ["user"],
    defaultSort: { sortBy: "name", direction: "desc" },
    alwaysSorted: true,
  })

  return (
    <ThemeProvider theme={createTheme()}>
      <HatchifyProvider>
        <TodoDataGrid
          defaultSort={{ sortBy: "name", direction: "desc" }}
          alwaysSorted
        />
        <hr />
        <Filters {...state} />
        <List {...state} />
        <Pagination {...state} />
      </HatchifyProvider>
    </ThemeProvider>
  )
}
```

# Definition of done

- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests?
- [ ] Is code secure? If applicable, add security notes to the description.
- [ ] Do all new TODO comments have Jira links with enough information?
- [ ] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
