### PR TITLE
fix: expand typescript support to null when allowNull is true

### DIFF
--- a/packages/rest-client/src/services/types/schema.ts
+++ b/packages/rest-client/src/services/types/schema.ts
@@ -59,24 +59,42 @@ type UnionToObject<
   TMutate extends boolean,
 > = {
   [Key in Union["key"]]: Extract<Union, { key: Key }> extends {
-    control: { type: infer Type; values?: infer EnumValues }
+    control: {
+      type: infer Type
+      values?: infer EnumValues
+      allowNullInfer: infer AllowNull
+    }
   }
     ? Type extends "Number"
-      ? number
+      ? AllowNull extends true
+        ? number | null
+        : number
       : Type extends "Boolean"
-        ? boolean
+        ? AllowNull extends true
+          ? boolean | null
+          : boolean
         : Type extends "enum"
-          ? EnumValues[any]
+          ? AllowNull extends true
+            ? EnumValues[any] | null
+            : EnumValues[any]
           : Type extends "String"
-            ? string
+            ? AllowNull extends true
+              ? string | null
+              : string
             : Type extends "Dateonly"
-              ? string
+              ? AllowNull extends true
+                ? string | null
+                : string
               : Type extends "Date"
                 ? TMutate extends true
-                  ? Date | string
-                  : Date
-                : "a"
-    : "b"
+                  ? AllowNull extends true
+                    ? Date | string | null
+                    : Date | string
+                  : AllowNull extends true
+                    ? Date | null
+                    : Date
+                : never
+    : never
 }
 
 // Extract subset of attributes from a union


### PR DESCRIPTION
# Description
- when an attribute is not required (allowNull) then the coerce function does not allow `undefined`, but the frontend was only supporting `<type> | undefined` with typescript
- expanded typescript to be `<type> | null | undefined`
  - even though `undefined` will throw an error in coerce function, it is required so that the field can be omitted entirely, ie. `createOne({ name: undefined })` will throw an error, but omitting the attribute entirely `createOne({})` works. TS cannot tell the difference between these 2 

# Test Plan
- manually tested

![Screenshot 2024-05-01 at 3 07 28 PM](https://github.com/bitovi/hatchify/assets/9858612/cefa06f6-a8a4-428b-9673-3ad88a8fa1c4)
![Screenshot 2024-05-01 at 3 07 33 PM](https://github.com/bitovi/hatchify/assets/9858612/17d1fa14-13f7-4f09-8615-eaf39a2425c9)


# Definition of done

- [ ] Does new code have 90% testing coverage (100% for `core`) of both unit and E2E tests?
- [ ] Is code secure? If applicable, add security notes to the description.
- [ ] Do all new TODO comments have Jira links with enough information?
- [ ] Has the browser error-console been reviewed to not contain new errors introduced by these code changes?
- [ ] The site looks “good” above 1000px width.
- [ ] The site looks “good” when the window height is small. No double scrollbars.
- [ ] Were the changes tested to ensure 508 compliance?
