### PR TITLE
feature: modify json api

### DIFF
--- a/packages/rest-client-jsonapi/src/services/createOne/createOne.ts
+++ b/packages/rest-client-jsonapi/src/services/createOne/createOne.ts
@@ -46,6 +46,7 @@ export async function createOne<
     "POST",
     `${config.baseUrl}/${config.schemaMap[schemaName].endpoint}`,
     jsonApiResource,
+    config.fetchOptions,
   )
 
   return Promise.resolve({

--- a/packages/rest-client-jsonapi/src/services/deleteOne/deleteOne.ts
+++ b/packages/rest-client-jsonapi/src/services/deleteOne/deleteOne.ts
@@ -29,6 +29,8 @@ export async function deleteOne<
   await fetchJsonApi(
     "DELETE",
     `${config.baseUrl}/${config.schemaMap[schemaName].endpoint}/${id}`,
+    undefined,
+    config.fetchOptions,
   )
 
   return Promise.resolve()

--- a/packages/rest-client-jsonapi/src/services/findAll/findAll.ts
+++ b/packages/rest-client-jsonapi/src/services/findAll/findAll.ts
@@ -60,6 +60,8 @@ export async function findAll<
   const json = await fetchJsonApi<JsonApiResource[]>(
     "GET",
     `${config.baseUrl}/${config.schemaMap[schemaName].endpoint}${queryParams}`,
+    undefined,
+    config.fetchOptions,
   )
 
   return Promise.resolve([

--- a/packages/rest-client-jsonapi/src/services/findOne/findOne.ts
+++ b/packages/rest-client-jsonapi/src/services/findOne/findOne.ts
@@ -43,6 +43,8 @@ export async function findOne<
   const json = await fetchJsonApi<JsonApiResource>(
     "GET",
     `${config.baseUrl}/${config.schemaMap[schemaName].endpoint}/${query.id}${queryParams}`,
+    undefined,
+    config.fetchOptions,
   )
 
   return Promise.resolve({

--- a/packages/rest-client-jsonapi/src/services/jsonapi/jsonapi.ts
+++ b/packages/rest-client-jsonapi/src/services/jsonapi/jsonapi.ts
@@ -31,7 +31,11 @@ export type CreateJsonApiResource = Omit<JsonApiResource, "id">
 export function jsonapi<
   const TSchemas extends Record<string, RestClientSchema>,
   const TSchemaName extends GetSchemaNames<TSchemas>,
->(baseUrl: string, schemaMap: TSchemas): RestClient<TSchemas, TSchemaName> {
+>(
+  baseUrl: string,
+  schemaMap: TSchemas,
+  fetchOptions?: RequestInit,
+): RestClient<TSchemas, TSchemaName> {
   // Default `type` to `schemaMap` key if not set in `schemaMap`
   const completeSchemaMap = Object.entries(schemaMap).reduce(
     (acc, [key, value]) => {
@@ -58,7 +62,11 @@ export function jsonapi<
     {} as RestClientSchemaMap,
   )
 
-  const config = { baseUrl, schemaMap: completeSchemaMap }
+  const config = {
+    baseUrl,
+    schemaMap: completeSchemaMap,
+    fetchOptions,
+  }
 
   return {
     completeSchemaMap: completeSchemaMap as TSchemas,

--- a/packages/rest-client-jsonapi/src/services/updateOne/updateOne.ts
+++ b/packages/rest-client-jsonapi/src/services/updateOne/updateOne.ts
@@ -48,6 +48,7 @@ export async function updateOne<
       "id" in jsonApiResource ? jsonApiResource.id : null
     }`,
     jsonApiResource,
+    config.fetchOptions,
   )
 
   return Promise.resolve({

--- a/packages/rest-client-jsonapi/src/services/utils/fetch/fetch.test.ts
+++ b/packages/rest-client-jsonapi/src/services/utils/fetch/fetch.test.ts
@@ -72,4 +72,44 @@ describe("rest-client-jsonapi/services/utils/fetch", () => {
       fetchJsonApi("GET", `${baseUrl}/${schemaMap.Article.endpoint}`),
     ).rejects.toEqual("Unknown error")
   })
+
+  it("applies custom fetchOptions correctly", async () => {
+    const customHeaders = {
+      Authorization: "Bearer test-token",
+      "Custom-Header": "test-value",
+    }
+
+    server.use(
+      http.get(
+        `${baseUrl}/${schemaMap.Article.endpoint}`,
+        async ({ request }) => {
+          // Verify the headers were properly set
+          expect(request.headers.get("Authorization")).toBe("Bearer test-token")
+          expect(request.headers.get("Custom-Header")).toBe("test-value")
+          expect(request.headers.get("Content-Type")).toBe(
+            "application/vnd.api+json",
+          )
+
+          return new Response(JSON.stringify(testData))
+        },
+        { once: true },
+      ),
+    )
+
+    const data = await fetchJsonApi(
+      "GET",
+      `${baseUrl}/${schemaMap.Article.endpoint}`,
+      undefined,
+      {
+        headers: customHeaders,
+        credentials: "include",
+      },
+    )
+
+    expect(data).toEqual({
+      data: testData.data,
+      included: testData.included,
+      meta: testData.meta,
+    })
+  })
 })

--- a/packages/rest-client-jsonapi/src/services/utils/fetch/fetch.test.ts
+++ b/packages/rest-client-jsonapi/src/services/utils/fetch/fetch.test.ts
@@ -30,6 +30,29 @@ describe("rest-client-jsonapi/services/utils/fetch", () => {
     })
   })
 
+  it("works with fetch options", async () => {
+    const customHeaders = new Headers({
+      Authorization: "Bearer test-token",
+      "Custom-Header": "test-value",
+    })
+
+    const data = await fetchJsonApi(
+      "GET",
+      `${baseUrl}/${schemaMap.Article.endpoint}`,
+      undefined,
+      {
+        headers: customHeaders,
+        credentials: "include",
+      },
+    )
+
+    expect(data).toEqual({
+      data: testData.data,
+      included: testData.included,
+      meta: testData.meta,
+    })
+  })
+
   it("throws an error if the request fails", async () => {
     const errors = [
       {
@@ -71,45 +94,5 @@ describe("rest-client-jsonapi/services/utils/fetch", () => {
     await expect(() =>
       fetchJsonApi("GET", `${baseUrl}/${schemaMap.Article.endpoint}`),
     ).rejects.toEqual("Unknown error")
-  })
-
-  it("applies custom fetchOptions correctly", async () => {
-    const customHeaders = {
-      Authorization: "Bearer test-token",
-      "Custom-Header": "test-value",
-    }
-
-    server.use(
-      http.get(
-        `${baseUrl}/${schemaMap.Article.endpoint}`,
-        async ({ request }) => {
-          // Verify the headers were properly set
-          expect(request.headers.get("Authorization")).toBe("Bearer test-token")
-          expect(request.headers.get("Custom-Header")).toBe("test-value")
-          expect(request.headers.get("Content-Type")).toBe(
-            "application/vnd.api+json",
-          )
-
-          return new Response(JSON.stringify(testData))
-        },
-        { once: true },
-      ),
-    )
-
-    const data = await fetchJsonApi(
-      "GET",
-      `${baseUrl}/${schemaMap.Article.endpoint}`,
-      undefined,
-      {
-        headers: customHeaders,
-        credentials: "include",
-      },
-    )
-
-    expect(data).toEqual({
-      data: testData.data,
-      included: testData.included,
-      meta: testData.meta,
-    })
   })
 })

--- a/packages/rest-client-jsonapi/src/services/utils/fetch/fetch.ts
+++ b/packages/rest-client-jsonapi/src/services/utils/fetch/fetch.ts
@@ -8,6 +8,7 @@ export async function fetchJsonApi<T>(
   method: "GET" | "POST" | "PATCH" | "DELETE",
   url: string,
   body?: { [key: string]: any },
+  fetchOptions?: RequestInit,
 ): Promise<{
   data: T
   included?: JsonApiResource[]
@@ -17,8 +18,10 @@ export async function fetchJsonApi<T>(
     method,
     body: body ? JSON.stringify({ data: body }) : undefined,
     headers: {
-      "Content-Type": "application/vnd.api+json",
+      ...fetchOptions?.headers,
+      "Content-Type": "application/vnd.api+json", // This will override any Content-Type in fetchOptions
     },
+    ...fetchOptions,
   })
 
   if (!response.ok) {

--- a/packages/rest-client/src/services/types/rest-client.ts
+++ b/packages/rest-client/src/services/types/rest-client.ts
@@ -30,6 +30,7 @@ export type RestClientSchemaMap = Record<
 export interface RestClientConfig {
   baseUrl: string
   schemaMap: RestClientSchemaMap
+  fetchOptions?: RequestInit
 }
 
 // always return a Resource[] even if it's a single resource because
@@ -45,6 +46,7 @@ export interface RestClient<
     schemaName: TSchemaName,
     query: QueryList<GetSchemaFromName<TSchemas, TSchemaName>>,
     baseFilter?: Filters,
+    fetchOptions?: RequestInit,
   ) => Promise<
     [
       Resources: { records: Resource[]; related: Resource[] },
@@ -55,20 +57,24 @@ export interface RestClient<
     allSchemas: FinalSchemas,
     schemaName: TSchemaName,
     query: QueryOne<GetSchemaFromName<TSchemas, TSchemaName>>,
+    fetchOptions?: RequestInit,
   ) => Promise<{ record: Resource; related: Resource[] }>
   createOne: (
     allSchemas: FinalSchemas,
     schemaName: TSchemaName,
     data: CreateType<GetSchemaFromName<TSchemas, TSchemaName>>,
+    fetchOptions?: RequestInit,
   ) => Promise<{ record: Resource; related: Resource[] }>
   updateOne: (
     allSchemas: FinalSchemas,
     schemaName: TSchemaName,
     data: UpdateType<GetSchemaFromName<TSchemas, TSchemaName>>,
+    fetchOptions?: RequestInit,
   ) => Promise<{ record: Resource; related: Resource[] }>
   deleteOne: (
     allSchemas: FinalSchemas,
     schemaName: TSchemaName,
     id: string,
+    fetchOptions?: RequestInit,
   ) => Promise<void>
 }


### PR DESCRIPTION
While implementing some new security features on my application, I wanted to be able to pass some session information between backend and frontend using cookies to use auth middleware in my backend. To support my desired usage, I've added fetch options to the createJsonapiClient from rest-client-jsonapi. 

I'm using to add the credentials option, and to enable using debug and token headers.

```
  const jsonAPI = createJsonapiClient(PORTAL_API_URL, Schemas, {
    credentials: "include",
  });
```

This PR adds support for custom fetch options across all REST client operations in the JSON:API implementation. This enables configuring custom headers, credentials, and other fetch-related options when making API requests.

## Changes
- Added `fetchOptions?: RequestInit` parameter to the REST client configuration
- Updated all service methods (findAll, findOne, createOne, updateOne, deleteOne) to accept fetchOptions
- Modified the `fetchJsonApi` utility to merge custom headers while preserving the required JSON:API content type
- Updated type definitions to include fetchOptions in method signatures

## Implementation Details
- Custom headers are merged with the default JSON:API content type header (`application/vnd.api+json`)
- FetchOptions can be set globally in the client configuration
